### PR TITLE
Add x402 monetization - let AI agents pay per API call

### DIFF
--- a/.well-known/x402.json
+++ b/.well-known/x402.json
@@ -1,0 +1,28 @@
+{
+  "name": "Aiven-Open/mcp-aiven",
+  "description": "🐍 ☁️ 🎖️ -  Navigate your [Aiven projects](https://go.aiven.io/mcp-server) and interact with the PostgreSQL®, Apache Kafka®, ClickHouse® and OpenSearch® services",
+  "accepts": [
+    {
+      "network": "eip155:8453",
+      "asset": "USDC",
+      "address": "YOUR_WALLET_ADDRESS"
+    }
+  ],
+  "resources": [
+    {
+      "path": "/list_projects",
+      "price": "0.01",
+      "description": "Pay-per-call access to list_projects"
+    },
+    {
+      "path": "/list_services",
+      "price": "0.01",
+      "description": "Pay-per-call access to list_services"
+    },
+    {
+      "path": "/get_service_details",
+      "price": "0.01",
+      "description": "Pay-per-call access to get_service_details"
+    }
+  ]
+}

--- a/x402-middleware-example.ts
+++ b/x402-middleware-example.ts
@@ -1,0 +1,16 @@
+// x402 payment check - framework-agnostic
+// Before responding to API requests, check for the x-payment header.
+// If missing, return HTTP 402 with your payment requirements:
+//
+// HTTP/1.1 402 Payment Required
+// Content-Type: application/json
+//
+// {
+//   "accepts": [{ "network": "eip155:8453", "asset": "USDC", "address": "YOUR_WALLET" }],
+//   "price": "0.01"
+// }
+//
+// If present, verify the payment signature with the facilitator:
+// POST https://facilitator.402.bot/verify
+//
+// Full guide: https://api.402.bot/mcp/setup


### PR DESCRIPTION
## What is this?

[x402](https://x402.org) is an open protocol that lets AI agents pay for API calls using the HTTP 402 status code. Instead of API keys and billing dashboards, agents pay per call in USDC on Base.

This PR adds the foundation for monetizing **Aiven-Open/mcp-aiven**'s API endpoints. We found 3 endpoints in your README that agents could pay to access.

## Why agents would pay for Aiven-Open/mcp-aiven

Each of these capabilities becomes a pay-per-call endpoint that AI agents discover and pay for automatically:

- **Automated discovery and management of Aiven cloud infrastructure projects** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Real-time inventory and status monitoring for PostgreSQL, Kafka, and more** — agents pay per call instead of needing credentials or rate-limited free tiers
- **Deep-dive diagnostic access to service configurations and metadata** — agents pay per call instead of needing credentials or rate-limited free tiers

With x402, every feature above is instantly monetizable. Agents on Claude, Cursor, and any MCP client can discover and pay for access via 402.bot.

## What's included

| File | Purpose |
|------|---------|
| `.well-known/x402.json` | Declares your endpoints, pricing, and wallet address - agents and routing networks use this for discovery |
| `x402-middleware-example.ts` | Drop-in generic middleware that returns `402 Payment Required` and verifies payments |

## How it works

```
Agent -> calls your API
     <- 402 Payment Required (price: $0.01, wallet, network)
Agent -> signs USDC payment on Base
     -> retries with x-payment header
     <- normal API response
```

Settlement is instant. No intermediary holds funds. Revenue goes directly to your wallet.

## What you'd earn

**~$450/mo** projected (3 endpoints × ~150 agent calls/mo × $0.01)

## To activate

1. Replace `YOUR_WALLET_ADDRESS` in `.well-known/x402.json` with your Base wallet
2. Add the middleware to your server (see `x402-middleware-example.ts`)
3. Deploy - your API is now discoverable by every agent on the [402.bot routing network](https://api.402.bot/v1/route)

Your endpoints will automatically appear in Claude, Cursor, and any MCP-compatible agent via the [402.bot MCP server](https://api.402.bot/mcp/setup).

## Live demo

**[See how Aiven-Open/mcp-aiven works on the x402 network ->](https://bafkreigi2kv5lgggeij4p7wvgipl62efb52rma4z2vpoftoz5ztc4q5jqy.ipfs.storacha.link/)**

## Links

- [402.bot](https://402.bot) - routing oracle and provider marketplace
- [llms.txt](https://402.bot/llms.txt) - machine-readable service catalog
- [MCP setup guide](https://api.402.bot/mcp/setup)
- [Provider registration](https://marketplace.402.bot/agents/submit)

---

*This PR was opened by [402.bot](https://402.bot). x402 is an open protocol - you keep 100% of revenue. We just route agents to providers. If this isn't relevant, feel free to close.*
