### PR TITLE
feat: mcp metrics headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,11 +7,13 @@ import { VERSION, API_BASE_URL } from './config.js';
 export class AivenClient {
   private readonly token: string | undefined;
   private readonly defaultTimeout: number;
+  private readonly transport: 'stdio' | 'http';
   private readonly fetchClient: ReturnType<typeof createClient<paths>>;
 
   constructor(config: AivenConfig) {
     this.token = config.token;
     this.defaultTimeout = 30000;
+    this.transport = config.transport;
     this.fetchClient = createClient<paths>({
       baseUrl: API_BASE_URL,
       headers: {
@@ -40,7 +42,7 @@ export class AivenClient {
       {
         params: options?.query ? { query: options.query } : undefined,
         body: body as never,
-        headers: { Authorization: `Bearer ${token}` },
+        headers: this.buildHeaders(token, options),
         signal: AbortSignal.timeout(timeout),
       } as never,
     )) as {
@@ -63,6 +65,20 @@ export class AivenClient {
     }
 
     return result.data as T;
+  }
+
+  private buildHeaders(token: string, options?: RequestOptions): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      'X-MCP-Transport': this.transport,
+    };
+    if (options?.toolName) {
+      headers['X-MCP-Tool-Name'] = options.toolName;
+    }
+    if (options?.mcpClient) {
+      headers['X-MCP-Client'] = options.mcpClient;
+    }
+    return headers;
   }
 
   async get<T>(path: string, options?: RequestOptions): Promise<T> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,5 +19,5 @@ export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
 
   const readOnly = process.env['AIVEN_READ_ONLY'] === 'true';
 
-  return { token, readOnly };
+  return { token, readOnly, transport };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,10 @@ function registerTools(server: McpServer, tools: ToolDefinition[]): void {
         ...(tool.definition.outputSchema ? { outputSchema: tool.definition.outputSchema } : {}),
       },
       async (params, extra) => {
-        const context = extra.authInfo ? { token: extra.authInfo.token } : undefined;
+        const context = {
+          token: extra.authInfo?.token,
+          mcpClient: server.server.getClientVersion()?.name,
+        };
         return tool.handler(params, context);
       }
     );

--- a/src/shared/service-info.ts
+++ b/src/shared/service-info.ts
@@ -1,5 +1,5 @@
 import type { AivenClient } from '../client.js';
-import type { ServiceConnectionInfo } from '../types.js';
+import type { RequestOptions, ServiceConnectionInfo } from '../types.js';
 
 interface ServiceUriParams {
   host: string;
@@ -22,10 +22,9 @@ interface CaCertResponse {
 export async function getProjectCaCert(
   client: AivenClient,
   project: string,
-  token?: string
+  opts?: RequestOptions
 ): Promise<string | undefined> {
   try {
-    const opts = token ? { token } : undefined;
     const data = await client.get<CaCertResponse>(
       `/project/${encodeURIComponent(project)}/kms/ca`,
       opts
@@ -40,9 +39,8 @@ export async function getServiceConnectionInfo(
   client: AivenClient,
   project: string,
   serviceName: string,
-  token?: string
+  opts?: RequestOptions
 ): Promise<ServiceConnectionInfo> {
-  const opts = token ? { token } : undefined;
   const data = await client.get<ServiceResponse>(
     `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}`,
     opts

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -86,7 +86,11 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
       try {
         const args = params as Record<string, unknown>;
-        const opts = context?.token ? { token: context.token } : undefined;
+        const opts: RequestOptions = {
+          token: context?.token,
+          mcpClient: context?.mcpClient,
+          toolName: config.name,
+        };
 
         const data = await executeRequest(client, config, args, pathParams, opts);
 

--- a/src/tools/kafka/handlers.ts
+++ b/src/tools/kafka/handlers.ts
@@ -32,9 +32,13 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
             Record<string, unknown>;
           const { project, service_name: serviceName } = typedParams;
 
-          const config = await buildConnectorConfig(client, typedParams, context?.token);
+          const opts = {
+            token: context?.token,
+            mcpClient: context?.mcpClient,
+            toolName: KafkaToolName.ConnectCreateConnector,
+          };
+          const config = await buildConnectorConfig(client, typedParams, opts);
 
-          const opts = context?.token ? { token: context.token } : undefined;
           const data = await client.post<Record<string, unknown>>(
             `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}/connectors`,
             config,
@@ -62,9 +66,13 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
           const typedParams = params as z.infer<typeof editConnectorInput> & Record<string, unknown>;
           const { project, service_name: serviceName, connector_name: connectorName } = typedParams;
 
-          const config = await buildConnectorConfig(client, typedParams, context?.token);
+          const opts = {
+            token: context?.token,
+            mcpClient: context?.mcpClient,
+            toolName: KafkaToolName.ConnectEditConnector,
+          };
+          const config = await buildConnectorConfig(client, typedParams, opts);
 
-          const opts = context?.token ? { token: context.token } : undefined;
           const data = await client.put<Record<string, unknown>>(
             `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}/connectors/${encodeURIComponent(connectorName)}`,
             config,

--- a/src/tools/kafka/helpers.ts
+++ b/src/tools/kafka/helpers.ts
@@ -1,5 +1,5 @@
 import type { AivenClient } from '../../client.js';
-import type { ServiceConnectionInfo } from '../../types.js';
+import type { RequestOptions, ServiceConnectionInfo } from '../../types.js';
 import { getServiceConnectionInfo } from '../../shared/service-info.js';
 
 const ROUTING_KEYS = new Set([
@@ -53,7 +53,7 @@ function detectFieldMapping(connectorClass: string): Record<string, string> | un
 export async function buildConnectorConfig(
   client: AivenClient,
   params: Record<string, unknown>,
-  token?: string
+  opts?: RequestOptions
 ): Promise<Record<string, unknown>> {
   const project = String(params['project']);
   const connectorClass = String(params['connector_class']);
@@ -69,7 +69,7 @@ export async function buildConnectorConfig(
   config['connector.class'] = connectorClass;
 
   if (sourceService) {
-    const connInfo = await getServiceConnectionInfo(client, project, sourceService, token);
+    const connInfo = await getServiceConnectionInfo(client, project, sourceService, opts);
 
     const fieldMapping = detectFieldMapping(connectorClass);
     if (fieldMapping) {

--- a/src/tools/pg/connection.ts
+++ b/src/tools/pg/connection.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import type { AivenClient } from '../../client.js';
+import type { RequestOptions } from '../../types.js';
 import { getServiceConnectionInfo, getProjectCaCert } from '../../shared/service-info.js';
 
 const CONNECTION_TIMEOUT_MS = 10000;
@@ -9,10 +10,10 @@ export async function connectToService(
   project: string,
   serviceName: string,
   database?: string,
-  token?: string
+  opts?: RequestOptions
 ): Promise<pg.Client> {
-  const connInfo = await getServiceConnectionInfo(client, project, serviceName, token);
-  const caCert = await getProjectCaCert(client, project, token);
+  const connInfo = await getServiceConnectionInfo(client, project, serviceName, opts);
+  const caCert = await getProjectCaCert(client, project, opts);
 
   const pgClient = new pg.Client({
     host: connInfo.host,

--- a/src/tools/pg/handlers.ts
+++ b/src/tools/pg/handlers.ts
@@ -36,7 +36,11 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
           const typedParams = params as z.infer<typeof optimizeQueryInput>;
           const encodedQuery = Buffer.from(typedParams.query).toString('base64');
 
-          const opts = context?.token ? { token: context.token } : undefined;
+          const opts = {
+            token: context?.token,
+            mcpClient: context?.mcpClient,
+            toolName: PgToolName.OptimizeQuery,
+          };
           const data = await client.post<Record<string, unknown>>(
             `/account/${typedParams.account_id}/pg/query/optimize`,
             {
@@ -76,6 +80,8 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
           limit,
           offset,
           token: context?.token,
+          mcpClient: context?.mcpClient,
+          toolName: PgToolName.Read,
         });
       },
     },
@@ -103,6 +109,8 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
           limit,
           offset,
           token: context?.token,
+          mcpClient: context?.mcpClient,
+          toolName: PgToolName.Write,
         });
       },
     },

--- a/src/tools/pg/query.ts
+++ b/src/tools/pg/query.ts
@@ -100,9 +100,11 @@ export async function executePgQuery(
   const rateLimitError = checkRateLimit(token);
   if (rateLimitError) return toolError(rateLimitError);
 
+  const apiOpts = { token, mcpClient: options.mcpClient, toolName: options.toolName };
+
   let pgClient;
   try {
-    pgClient = await connectToService(client, project, service_name, database, token);
+    pgClient = await connectToService(client, project, service_name, database, apiOpts);
   } catch (err) {
     return toolError(errorMessage(err));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,12 +12,15 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 export interface AivenConfig {
   readonly token: string | undefined;
   readonly readOnly: boolean;
+  readonly transport: 'stdio' | 'http';
 }
 
 export interface RequestOptions {
   query?: Record<string, string | number | boolean | undefined> | undefined;
   timeout?: number | undefined;
   token?: string | undefined;
+  toolName?: string | undefined;
+  mcpClient?: string | undefined;
 }
 
 export interface ToolAnnotations {
@@ -66,6 +69,7 @@ export type ToolResult = CallToolResult;
 
 export interface HandlerContext {
   token?: string | undefined;
+  mcpClient?: string | undefined;
 }
 
 export interface ToolDefinition<TInput extends z.ZodType = z.ZodType> {
@@ -165,6 +169,8 @@ export interface ExecutePgQueryOptions {
   limit?: number | undefined;
   offset?: number | undefined;
   token?: string | undefined;
+  mcpClient?: string | undefined;
+  toolName?: string | undefined;
 }
 
 export enum KafkaToolName {


### PR DESCRIPTION
# MCP Headers

Every outgoing request now includes X-MCP-Tool-Name, X-MCP-Client, and X-MCP-Transport (stdio/http) headers for server-side metrics and access log tracking in aiven.