### PR TITLE
mcp: refuse PostgreSQL connection when CA certificate is unavailable [EVERSQL-1759]

### DIFF
--- a/src/shared/service-info.ts
+++ b/src/shared/service-info.ts
@@ -23,17 +23,20 @@ export async function getProjectCaCert(
   client: AivenClient,
   project: string,
   token?: string
-): Promise<string | undefined> {
-  try {
-    const opts = token ? { token } : undefined;
-    const data = await client.get<CaCertResponse>(
-      `/project/${encodeURIComponent(project)}/kms/ca`,
-      opts
+): Promise<string> {
+  const opts = token ? { token } : undefined;
+  const data = await client.get<CaCertResponse>(
+    `/project/${encodeURIComponent(project)}/kms/ca`,
+    opts
+  );
+  if (!data.certificate) {
+    throw new Error(
+      `Failed to retrieve the CA certificate for project "${project}". ` +
+        'A valid CA certificate is required to securely connect to PostgreSQL. ' +
+        'Refusing to connect without TLS verification.'
     );
-    return data.certificate;
-  } catch {
-    return undefined;
   }
+  return data.certificate;
 }
 
 export async function getServiceConnectionInfo(

--- a/src/tools/pg/connection.ts
+++ b/src/tools/pg/connection.ts
@@ -20,7 +20,7 @@ export async function connectToService(
     user: connInfo.user,
     password: connInfo.password,
     database: database ?? connInfo.dbname,
-    ssl: caCert ? { rejectUnauthorized: true, ca: caCert } : { rejectUnauthorized: false },
+    ssl: { rejectUnauthorized: true, ca: caCert },
     connectionTimeoutMillis: CONNECTION_TIMEOUT_MS,
   });
 


### PR DESCRIPTION
Previously, if the project CA certificate fetch failed for any reason, the PostgreSQL connection silently fell back to `rejectUnauthorized: false`, disabling TLS verification and allowing potential MITM attacks. Now the server throws a clear error instead.

[https://aiven.atlassian.net/browse/EVERSQL-1759](https://aiven.atlassian.net/browse/EVERSQL-1759)