### PR TITLE
filter service_type_plans fields to reduce context size

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -41,7 +41,7 @@ tools:
     category: core
     response_filter:
       key: service_plans
-      fields: [service_plan, node_count, service_type, regions, clouds]
+      fields: [service_plan]
     description: |
       List available plans for a service type. Requires `project` — use `aiven_project_list` first if unknown.
 


### PR DESCRIPTION
Temporary change - filter node_count, service_type, regions, clouds fields in the aiven_service_type_plans, so context will be smaller in mcp clients.
* I tested service creation and it works without those fields


Before:
<img width="1347" height="179" alt="Screenshot 2026-03-31 at 14 44 26" src="https://github.com/user-attachments/assets/200beb5e-f02f-41a7-b69c-9efb26c8c13e" />

After:
<img width="1370" height="191" alt="Screenshot 2026-03-31 at 14 44 44" src="https://github.com/user-attachments/assets/98454053-f9ec-4eb8-a600-6e7b158b9107" />


