### PR TITLE
feat: aiven apps vpc

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -184,6 +184,21 @@ tools:
 
       If the service type is unknown, call **`aiven_service_get`** first, then choose this tool if `service_type` is `application`.
 
+  - name: aiven_project_vpc_list
+    method: GET
+    path: /project/{project}/vpcs
+    category: core
+    readOnly: true
+    response_filter:
+      key: vpcs
+      fields: [project_vpc_id, cloud_name, state, network_cidr]
+    description: |
+      List VPCs for a project. Returns each VPC's ID, cloud, state, and network CIDR.
+
+      Use this when deploying an application service fails with "please specify project_vpc_id" (i.e. the project has multiple active VPCs). List them, show the user the options, and let them pick which VPC to deploy into.
+
+      VPCs with state `ACTIVE` are ready to use. Pass the chosen `project_vpc_id` to `aiven_application_deploy`.
+
   - name: aiven_project_get_event_logs
     method: GET
     path: /project/{project}/events

--- a/src/tools/applications/handlers.ts
+++ b/src/tools/applications/handlers.ts
@@ -5,13 +5,18 @@ import {
   ServiceCategory,
   ApplicationToolName,
   CREATE_ANNOTATIONS,
+  UPDATE_ANNOTATIONS,
   toolSuccess,
   toolError,
 } from '../../types.js';
 import { errorMessage } from '../../errors.js';
 import { redactSensitiveData } from '../../security.js';
 import { getProjectCaCert } from '../../shared/service-info.js';
-import { deployApplicationInput } from './schemas.js';
+import {
+  deployApplicationInput,
+  redeployApplicationInput,
+  type ServiceIntegrationInput,
+} from './schemas.js';
 
 interface ServiceResponse {
   service: {
@@ -39,20 +44,6 @@ async function fetchServiceDetails(
   return result.service;
 }
 
-async function fetchServiceUri(
-  client: AivenClient,
-  project: string,
-  serviceName: string,
-  token?: string
-): Promise<string> {
-  const service = await fetchServiceDetails(client, project, serviceName, token);
-  const uri = service.service_uri;
-  if (!uri) {
-    throw new Error(`No connection URI available for service ${serviceName}. Ensure the service is running.`);
-  }
-  return uri;
-}
-
 async function fetchAppUrl(
   client: AivenClient,
   project: string,
@@ -65,6 +56,44 @@ async function fetchAppUrl(
     throw new Error(`No public URL available for application service ${serviceName}. Ensure the service is running.`);
   }
   return component.path;
+}
+
+interface ApiServiceIntegration {
+  integration_type: 'application_service_credential';
+  source_service: string;
+  user_config: Record<string, string>;
+}
+
+/**
+ * Maps a service_integrations input item to the API shape for application_service_credential.
+ * pg / valkey / opensearch all use a single connection_string_environment_variable_name.
+ * kafka exposes all 5 SSL credential env var names so the app code never needs to change.
+ */
+function buildServiceIntegration(integration: ServiceIntegrationInput): ApiServiceIntegration {
+  if (integration.service_type === 'kafka') {
+    return {
+      integration_type: 'application_service_credential',
+      source_service: integration.service_name,
+      user_config: {
+        service_type: 'kafka',
+        bootstrap_servers_environment_variable_name: integration.bootstrap_servers_env,
+        security_protocol_environment_variable_name: integration.security_protocol_env,
+        access_key_environment_variable_name: integration.access_key_env,
+        access_cert_environment_variable_name: integration.access_cert_env,
+        ca_cert_environment_variable_name: integration.ca_cert_env,
+      },
+    };
+  }
+
+  // pg, valkey, opensearch share the same user_config shape
+  return {
+    integration_type: 'application_service_credential',
+    source_service: integration.service_name,
+    user_config: {
+      service_type: integration.service_type,
+      connection_string_environment_variable_name: integration.env_key,
+    },
+  };
 }
 
 export function createApplicationTools(client: AivenClient): ToolDefinition[] {
@@ -82,11 +111,23 @@ Inspect the local project files and confirm each applicable item. Report finding
 
 - \`build_path\` → verify Dockerfile exists, contains \`EXPOSE\` matching \`port\` param, has \`CMD\`/\`ENTRYPOINT\`
 - \`port\` → verify app source binds to \`0.0.0.0\`, not \`localhost\`/\`127.0.0.1\`
-- \`pg_service_name\` → verify PG service is RUNNING (\`aiven_service_get\`); source reads \`pg_env_key\` env var and base64-decodes \`PROJECT_CA_CERT\` for SSL; Node.js must strip \`sslmode\` from URL
+- \`service_integrations\` → for each entry, verify the source service is RUNNING (\`aiven_service_get\`); verify app reads the configured env var names
+- PostgreSQL/Valkey SSL → the deploy tool injects \`PROJECT_CA_CERT\` (base64-encoded Aiven CA cert). App code MUST strip \`sslmode\` from the connection URL (pg v8 ignores the \`ssl\` option when \`sslmode\` is in the URL) and use the CA cert for proper TLS. Required pattern for Node.js pg client:
+  \`\`\`js
+  const url = new URL(process.env.DATABASE_URL);
+  url.searchParams.delete('sslmode');
+  const pool = new pg.Pool({
+    connectionString: url.toString(),
+    ssl: { ca: Buffer.from(process.env.PROJECT_CA_CERT, 'base64').toString() },
+  });
+  \`\`\`
+  Verify this pattern exists in the source before deploying. If missing, add it and push before calling this tool.
+- OpenSearch SSL → Aiven OpenSearch uses a publicly-trusted TLS certificate. No \`PROJECT_CA_CERT\` is injected and none is needed. App code should connect using the \`OPENSEARCH_URL\` directly without any custom CA cert (the default system trust store is sufficient).
 - \`app_service_name\` → verify target app is RUNNING (\`aiven_service_get\`); source reads \`app_env_key\` env var
 - \`repository_url\` → ask the user to provide the repo URL and confirm code is pushed to \`branch\`
 - \`.gitignore\` → verify \`node_modules/\` and \`dist/\` are listed so they are not pushed to the repo
 - Dockerfile → use \`npm install\` (not \`npm ci\`) and only \`COPY package.json\` — lockfiles may not be in the repo
+- \`project_vpc_id\` → normally not needed — the backend auto-selects the VPC when the project has exactly one. Only required if the project has multiple VPCs (the API will return a CONFLICT error asking you to specify); in that case call \`aiven_project_vpc_list\` to list VPCs and ask the user which to use
 
 Example Dockerfile for a TypeScript Node.js app:
 \`\`\`dockerfile
@@ -115,13 +156,13 @@ CMD ["node", "dist/index.js"]
           plan,
           cloud,
           environment_variables: envVars,
-          pg_service_name: pgServiceName,
-          pg_env_key: pgEnvKey,
+          service_integrations: serviceIntegrationsInput,
           app_service_name: appServiceName,
           app_env_key: appEnvKey,
+          project_vpc_id: projectVpcId,
         } = params as z.infer<typeof deployApplicationInput>;
 
-        // Build environment variables list
+        // Build environment variables list (user-provided only)
         const allEnvVars: { key: string; kind: string; value: string }[] = [];
 
         if (envVars && envVars.length > 0) {
@@ -130,23 +171,34 @@ CMD ["node", "dist/index.js"]
           }
         }
 
-        // Resolve PG service URI and project CA certificate if requested
-        if (pgServiceName) {
-          try {
-            const uri = await fetchServiceUri(client, project, pgServiceName, context?.token);
-            allEnvVars.push({ key: pgEnvKey, kind: 'secret', value: uri });
+        // Build service integrations for automatic credential injection
+        const serviceIntegrations =
+          serviceIntegrationsInput?.map(buildServiceIntegration) ?? [];
 
+        // Inject PROJECT_CA_CERT when connecting to services that use TLS with Aiven's self-signed CA.
+        // Matches App Builder behaviour: fetch from /project/{project}/kms/ca and base64-encode.
+        // Kafka credentials are injected as raw PEM files by the platform itself — no CA cert needed here.
+        const needsCaCert = serviceIntegrationsInput?.some(
+          (i) => i.service_type === 'pg' || i.service_type === 'valkey'
+        );
+        if (needsCaCert) {
+          try {
             const caCert = await getProjectCaCert(client, project, context?.token);
             if (caCert) {
-              const encoded = Buffer.from(caCert).toString('base64');
-              allEnvVars.push({ key: 'PROJECT_CA_CERT', kind: 'variable', value: encoded });
+              allEnvVars.push({
+                key: 'PROJECT_CA_CERT',
+                kind: 'secret',
+                value: Buffer.from(caCert).toString('base64'),
+              });
             }
           } catch (err) {
-            return toolError(errorMessage(err));
+            return toolError(
+              `Failed to fetch project CA certificate required for TLS with pg/valkey: ${errorMessage(err)}`
+            );
           }
         }
 
-        // Resolve application service URL if requested
+        // Resolve application service URL if requested (app-to-app, not a credential integration)
         if (appServiceName) {
           try {
             const url = await fetchAppUrl(client, project, appServiceName, context?.token);
@@ -181,7 +233,8 @@ CMD ["node", "dist/index.js"]
           service_type: 'application',
           plan,
           cloud,
-          service_integrations: [],
+          ...(projectVpcId !== undefined ? { project_vpc_id: projectVpcId } : {}),
+          service_integrations: serviceIntegrations.length > 0 ? serviceIntegrations : undefined,
           user_config: {
             application: applicationConfig,
           },
@@ -208,6 +261,52 @@ CMD ["node", "dist/index.js"]
           }
 
           return toolSuccess(redactSensitiveData(result));
+        } catch (err) {
+          return toolError(errorMessage(err));
+        }
+      },
+    },
+    {
+      name: ApplicationToolName.Redeploy,
+      category: ServiceCategory.Application,
+      definition: {
+        title: 'Redeploy Application',
+        description: `Rebuild and redeploy an existing Aiven application service after new code has been pushed to its repository.
+
+Use this ONLY when:
+- The application service already exists and was previously deployed successfully with \`aiven_application_deploy\`
+- The user has pushed a code change to the same repository and branch the service was deployed from
+- Everything else stays the same: same repo, same branch, same port, same service configuration
+
+Do NOT use this tool:
+- When the Aiven service itself was never created (e.g. \`aiven_application_deploy\` returned an API error and no service exists) — call \`aiven_application_deploy\` again instead.
+- To change service configuration (plan, cloud, env vars, integrations) — use \`aiven_service_update\` or redeploy via \`aiven_application_deploy\` with updated parameters.
+
+Runtime errors in the app (500s, crashes, SSL errors) are NOT deploy failures — the service exists and is running. Use this tool to pick up a code fix in those cases.
+
+The rebuild pulls the latest commit from the configured branch and rebuilds the Docker image. It does not change any service settings.`,
+        inputSchema: redeployApplicationInput,
+        annotations: UPDATE_ANNOTATIONS,
+      },
+      handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
+        const { project, service_name: serviceName } = params as z.infer<typeof redeployApplicationInput>;
+
+        try {
+          const opts = context?.token ? { token: context.token } : undefined;
+
+          // No dedicated redeploy endpoint exists yet. A no-op service update (empty PUT body)
+          // triggers Meta Core's Executor to pick up the change and redeploy — same mechanism
+          // used by the Aiven Console redeploy button.
+          await client.put<Record<string, unknown>>(
+            `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}`,
+            {},
+            opts
+          );
+
+          return toolSuccess({
+            service_name: serviceName,
+            message: 'Redeploy triggered. The service will pull latest code, rebuild, and deploy.',
+          });
         } catch (err) {
           return toolError(errorMessage(err));
         }

--- a/src/tools/applications/schemas.ts
+++ b/src/tools/applications/schemas.ts
@@ -9,6 +9,107 @@ const environmentVariableItem = z.object({
     .describe('variable = visible in UI, secret = masked in UI. Use secret for tokens, passwords, URIs.'),
 });
 
+/**
+ * One entry in service_integrations. The platform uses these to automatically inject
+ * credentials into the running container as environment variables — no manual copy-paste
+ * of connection strings needed, and no app code changes required.
+ *
+ * Set env var names to match what your application already reads.
+ *
+ * Supported service_type values (must be an existing service in the same project):
+ *   - "pg"          → injects a postgres:// connection URI
+ *   - "valkey"      → injects a redis:// connection URI
+ *   - "opensearch"  → injects an https:// connection URI
+ *   - "kafka"       → injects bootstrap servers + SSL certificates (raw PEM strings)
+ */
+export const serviceIntegrationItem = z.discriminatedUnion('service_type', [
+  z.object({
+    service_type: z.literal('pg'),
+    service_name: z
+      .string()
+      .describe('Name of the existing Aiven PostgreSQL service in the same project (must be RUNNING).'),
+    env_key: z
+      .string()
+      .default('DATABASE_URL')
+      .describe(
+        'Env var your app reads for the PostgreSQL connection URI (full postgres:// URI with SSL params). ' +
+          'Set to match your app — do not change your app code to fit the default. Default: "DATABASE_URL".'
+      ),
+  }),
+
+  z.object({
+    service_type: z.literal('valkey'),
+    service_name: z
+      .string()
+      .describe('Name of the existing Aiven Valkey service in the same project (must be RUNNING).'),
+    env_key: z
+      .string()
+      .default('REDIS_URL')
+      .describe(
+        'Env var your app reads for the Valkey connection URI (redis:// URI). ' +
+          'Set to match your app — do not change your app code to fit the default. Default: "REDIS_URL".'
+      ),
+  }),
+
+  z.object({
+    service_type: z.literal('opensearch'),
+    service_name: z
+      .string()
+      .describe('Name of the existing Aiven OpenSearch service in the same project (must be RUNNING).'),
+    env_key: z
+      .string()
+      .default('OPENSEARCH_URL')
+      .describe(
+        'Env var your app reads for the OpenSearch connection URI (https:// URI). ' +
+          'Set to match your app — do not change your app code to fit the default. Default: "OPENSEARCH_URL".'
+      ),
+  }),
+
+  z.object({
+    service_type: z.literal('kafka'),
+    service_name: z
+      .string()
+      .describe('Name of the existing Aiven Kafka service in the same project (must be RUNNING).'),
+    bootstrap_servers_env: z
+      .string()
+      .default('KAFKA_BOOTSTRAP_SERVER')
+      .describe(
+        'Env var your app reads for Kafka bootstrap servers (comma-separated host:port). ' +
+          'Set to match your app. Default: "KAFKA_BOOTSTRAP_SERVER".'
+      ),
+    security_protocol_env: z
+      .string()
+      .default('KAFKA_SECURITY_PROTOCOL')
+      .describe(
+        'Env var your app reads for the security protocol (value will be "SSL"). ' +
+          'Set to match your app. Default: "KAFKA_SECURITY_PROTOCOL".'
+      ),
+    access_key_env: z
+      .string()
+      .default('KAFKA_ACCESS_KEY')
+      .describe(
+        'Env var your app reads for the SSL client private key (raw PEM string, NOT base64). ' +
+          'Set to match your app. Default: "KAFKA_ACCESS_KEY".'
+      ),
+    access_cert_env: z
+      .string()
+      .default('KAFKA_ACCESS_CERT')
+      .describe(
+        'Env var your app reads for the SSL client certificate (raw PEM string, NOT base64). ' +
+          'Set to match your app. Default: "KAFKA_ACCESS_CERT".'
+      ),
+    ca_cert_env: z
+      .string()
+      .default('KAFKA_CA_CERT')
+      .describe(
+        'Env var your app reads for the CA certificate (raw PEM string, NOT base64). ' +
+          'Set to match your app. Default: "KAFKA_CA_CERT".'
+      ),
+  }),
+]);
+
+export type ServiceIntegrationInput = z.infer<typeof serviceIntegrationItem>;
+
 export const deployApplicationInput = z
   .object({
     project: z.string().describe('Aiven project name — use aiven_project_list to get valid names'),
@@ -59,9 +160,9 @@ export const deployApplicationInput = z
 
     plan: z
       .string()
-      .default('free-10-256')
+      .default('startup-50-1024')
       .describe(
-        'Service plan. Default: "free-10-256" (free tier: shared CPU, 256MB RAM). ' +
+        'Service plan. Default: "startup-50-1024" (0.5 vCPU, 1024 MB RAM). ' +
           'Use aiven_service_type_plans with service_type="application" to list available plans.'
       ),
 
@@ -69,7 +170,7 @@ export const deployApplicationInput = z
       .string()
       .default('aws-eu-west-1')
       .describe(
-        'Cloud region for deployment. Always use the default "aws-eu-west-1" unless the user explicitly requests a different region.'
+        'Cloud region for deployment. Always confirm with the user before proceeding unless they have already explicitly specified a region. If service_integrations are provided, call aiven_service_get on each integrated service first and check their cloud_name: if all share the same cloud, propose that cloud and ask the user to confirm; if they differ, list the options and ask the user to choose. If there are no integrated services, ask the user which cloud region to deploy into.'
       ),
 
     environment_variables: z
@@ -77,30 +178,24 @@ export const deployApplicationInput = z
       .optional()
       .describe(
         'Additional environment variables to inject into the running container. ' +
-          'Do NOT include DATABASE_URL or PROJECT_CA_CERT here if using pg_service_name — those are auto-injected. ' +
+          'Do NOT include credentials for services listed in service_integrations — those are auto-injected by the platform. ' +
           'Common additions: NODE_ENV=production, PORT (matching the port param).'
       ),
 
-    pg_service_name: z
-      .string()
+    service_integrations: z
+      .array(serviceIntegrationItem)
       .optional()
       .describe(
-        'Name of an EXISTING Aiven PostgreSQL service in the same project. ' +
-          'When set, two env vars are auto-injected into the container:\n' +
-          '  1. DATABASE_URL (or custom pg_env_key) — full postgres:// connection URI with SSL params\n' +
-          '  2. PROJECT_CA_CERT — the project CA certificate, BASE64-ENCODED\n\n' +
-          'CRITICAL: The application code MUST base64-decode PROJECT_CA_CERT before using it for SSL. ' +
-          'Example (Node.js): Buffer.from(process.env.PROJECT_CA_CERT, "base64").toString()\n' +
-          'Example (Python): base64.b64decode(os.environ["PROJECT_CA_CERT"]).decode()\n\n' +
-          'The PG service must be in RUNNING state. Use aiven_service_get to verify before deploying.'
-      ),
-
-    pg_env_key: z
-      .string()
-      .default('DATABASE_URL')
-      .describe(
-        'Environment variable name for the PostgreSQL connection URI. Default: "DATABASE_URL". ' +
-          'Only relevant when pg_service_name is set.'
+        'Aiven services to connect to this application. The platform automatically injects credentials ' +
+          'as environment variables — no manual connection strings needed, and your app code does not need to change. ' +
+          'Set env var names to match what your application already reads.\n\n' +
+          'Supported service types: "pg", "valkey", "opensearch", "kafka".\n' +
+          'Each service must already exist in the same project and be in RUNNING state (verify with aiven_service_get).\n\n' +
+          'Example — connect to Postgres and Kafka:\n' +
+          '  service_integrations: [\n' +
+          '    { service_type: "pg", service_name: "my-pg", env_key: "DATABASE_URL" },\n' +
+          '    { service_type: "kafka", service_name: "my-kafka", bootstrap_servers_env: "KAFKA_BROKERS" }\n' +
+          '  ]'
       ),
 
     app_service_name: z
@@ -119,5 +214,23 @@ export const deployApplicationInput = z
         'Environment variable name for the connected application URL. Default: "API_URL". ' +
           'Only relevant when app_service_name is set.'
       ),
+
+    project_vpc_id: z
+      .string()
+      .optional()
+      .describe(
+        'VPC to deploy this application into. Normally omit this — the backend auto-selects the VPC ' +
+          'when the project has exactly one active VPC in the target cloud. ' +
+          'Only provide this if the API returns a CONFLICT error saying the project has multiple VPCs ' +
+          'and you must specify one. In that case, call aiven_project_vpc_list to list available VPCs ' +
+          'and ask the user which to use.'
+      ),
+  })
+  .strict();
+
+export const redeployApplicationInput = z
+  .object({
+    project: z.string().describe('Aiven project name'),
+    service_name: z.string().describe('Name of the existing application service to redeploy'),
   })
   .strict();

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export interface ExecutePgQueryOptions {
 
 export enum ApplicationToolName {
   Deploy = 'aiven_application_deploy',
+  Redeploy = 'aiven_application_redeploy',
 }
 
 // ---------- Kafka ----------


### PR DESCRIPTION
* Deploy applications with integrations to services: PG, Kafka, Valkey and Opensearch. Replaces the PG specific env vars that were injected.

* New tool: aiven_project_vpc_list — lists VPCs for a project (id, cloud, state, CIDR). Used when deploy fails due to multiple VPCs requiring explicit selection. (Note: by default, not sending vpc param will require backend to try choose VPC if only one exists).

* Default plan changed from free-10-256 to startup-50-1024  (free was deprecated)
* Added redeploy tool, when app is already deployed, but we fixed bugs in code and want to redeploy.
* Clarify on cloud selection for application deploy to ask user for approval, and recommend on cloud where integrated services exist.