### PR TITLE
inject client name in http headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -36,13 +36,16 @@ export class AivenClient {
     }
 
     const timeout = options?.timeout ?? this.defaultTimeout;
+    const perRequestHeaders = this.buildHeaders(token, options);
+    this.logAivenRequest(method, path, perRequestHeaders);
+
     const result = (await this.fetchClient.request(
       method.toLowerCase() as never,
       path as never,
       {
         params: options?.query ? { query: options.query } : undefined,
         body: body as never,
-        headers: this.buildHeaders(token, options),
+        headers: perRequestHeaders,
         signal: AbortSignal.timeout(timeout),
       } as never,
     )) as {
@@ -65,6 +68,21 @@ export class AivenClient {
     }
 
     return result.data as T;
+  }
+
+  private logAivenRequest(method: HttpMethod, path: string, perRequestHeaders: Record<string, string>): void {
+    const url = `${API_BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+    const merged: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'User-Agent': `mcp-aiven/${VERSION}`,
+      ...perRequestHeaders,
+    };
+    const forLog = { ...merged };
+    if (forLog['Authorization']?.startsWith('Bearer ')) {
+      forLog['Authorization'] = 'Bearer [REDACTED]';
+    }
+    console.error('mcp-aiven: Aiven request %s %s headers=%s', method, url, JSON.stringify(forLog));
   }
 
   private buildHeaders(token: string, options?: RequestOptions): Record<string, string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,19 @@ import type { ToolDefinition } from './types.js';
 import { VERSION, API_ORIGIN } from './config.js';
 import { READ_ONLY_INSTRUCTIONS } from './prompts.js';
 
+/** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
+function mcpClientFromRequestInfo(requestInfo: unknown): string | undefined {
+  if (!requestInfo || typeof requestInfo !== 'object' || !('headers' in requestInfo)) {
+    return undefined;
+  }
+  const headersRaw = (requestInfo as { headers: unknown }).headers;
+  if (!headersRaw || typeof headersRaw !== 'object') return undefined;
+  const h = headersRaw as Record<string, string | undefined>;
+
+  const v = h['user-agent'] ?? h['User-Agent'];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
 function loadTools(client: AivenClient, readOnly: boolean): ToolDefinition[] {
   let tools: ToolDefinition[] = [
     ...loadApiTools(client),
@@ -40,7 +53,7 @@ function registerTools(server: McpServer, tools: ToolDefinition[]): void {
       async (params, extra) => {
         const context = {
           token: extra.authInfo?.token,
-          mcpClient: server.server.getClientVersion()?.name,
+          mcpClient: mcpClientFromRequestInfo(extra.requestInfo) ?? server.server.getClientVersion()?.name,
         };
         return tool.handler(params, context);
       }


### PR DESCRIPTION
[[JIRA](https://aiven.atlassian.net/jira/software/c/projects/EVERSQL/boards/234?assignee=712020%3Aca98ee31-fdc0-419a-8263-6afed86dfad6&selectedIssue=EVERSQL-1763)]

Forward client name to Acorn as `X-MCP-Client`, and log each outbound request from the MCP server for tracing.
