### PR TITLE
fix: return 405 on SSE get request

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -46,6 +46,14 @@ export function startHttpServer(
     });
   });
 
+  app.get('/mcp', (_req: Request, res: Response) => {
+    res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
+  });
+
+  app.delete('/mcp', (_req: Request, res: Response) => {
+    res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
+  });
+
   app.post('/mcp', authMiddleware, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
       const token = (req as Request & { token: string }).token;


### PR DESCRIPTION
This PR should solve the endless reconnects due to missing /GET request returning 405 for NO SSE support indication

[MCP relevant documentation](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server)