### PR TITLE
mcp: Add service to service integrations [EVERSQL-1760]

### DIFF
--- a/src/manifests/integrations.yaml
+++ b/src/manifests/integrations.yaml
@@ -1,0 +1,72 @@
+# Service integration tools: CRUD for integrations between Aiven services and external endpoints
+
+tools:
+  - name: aiven_service_integration_list
+    method: GET
+    path: /project/{project}/service/{service_name}/integration
+    category: integrations
+    readOnly: true
+    append_list_picker_hint: true
+    description: |
+      List all integrations for a specific service. Returns both integrations where this service is the source and where it is the destination.
+
+      Use this to see what metrics, logs, data pipeline, or replication integrations are active on a service.
+
+  - name: aiven_service_integration_create
+    method: POST
+    path: /project/{project}/integration
+    category: integrations
+    description: |
+      Create a service integration between two Aiven services, or between an Aiven service and an external integration endpoint.
+
+      **Before calling:** use `aiven_integration_types_list` to discover valid `integration_type` values and which source/destination service types each supports.
+
+      Provide `source_service`/`dest_service` for Aiven-to-Aiven integrations, or use `source_endpoint_id`/`dest_endpoint_id` for external endpoints.
+
+  - name: aiven_service_integration_get
+    method: GET
+    path: /project/{project}/integration/{integration_id}
+    category: integrations
+    readOnly: true
+    description: |
+      Get details for a specific service integration by ID. Returns the integration type, source and destination services, status, and configuration.
+
+  - name: aiven_service_integration_update
+    method: PUT
+    path: /project/{project}/integration/{integration_id}
+    category: integrations
+    description: |
+      Update the configuration of an existing service integration.
+
+      Only `user_config` can be updated — you cannot change the integration type, source, or destination after creation. To change those, delete and recreate the integration.
+
+  - name: aiven_service_integration_delete
+    method: DELETE
+    path: /project/{project}/integration/{integration_id}
+    category: integrations
+    description: |
+      Delete a service integration. This removes the connection between the source and destination services.
+
+      **Warning:** Deleting an integration may disrupt data flows (metrics, logs, replication). Confirm with the user before proceeding.
+
+  - name: aiven_integration_types_list
+    method: GET
+    path: /project/{project}/integration_types
+    category: integrations
+    readOnly: true
+    append_list_picker_hint: true
+    description: |
+      List all available service integration types for a project. Returns the integration type name along with the valid source and destination service types for each.
+
+      **Call this first** before creating an integration to understand which service types can be connected and in which direction.
+
+  - name: aiven_integration_endpoint_types_list
+    method: GET
+    path: /project/{project}/integration_endpoint_types
+    category: integrations
+    readOnly: true
+    append_list_picker_hint: true
+    description: |
+      List all available integration endpoint types for a project. Integration endpoints represent external services (e.g. Datadog, external Elasticsearch, Prometheus remote write, rsyslog, AWS CloudWatch, Google Cloud Logging).
+
+      Use this to discover what external endpoint types can be created, then use `aiven_service_integration_create` with the endpoint ID to wire an Aiven service to the external system.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -53,6 +53,7 @@ const CATEGORY_MAP: Record<string, ServiceCategory> = {
   core: ServiceCategory.Core,
   pg: ServiceCategory.Pg,
   kafka: ServiceCategory.Kafka,
+  integrations: ServiceCategory.Integrations,
 };
 
 function toCategory(cat: string): ServiceCategory {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export enum ServiceCategory {
   Pg = 'pg',
   Kafka = 'kafka',
   Application = 'application',
+  Integrations = 'integrations',
 }
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does
Adding tools for Integrations APIs:
* Create, inspect, update, and delete integrations (aiven_service_integration_create, _get, _update, _delete)
* Discover what integrations are possible (often needed before Create) (aiven_integration_types_list, aiven_integration_endpoint_types_list)
* List active integrations on any service (aiven_service_integration_list)

**Examples flows:**
* Integrate an **existing** MC application to services (PG, kafka. etc)
* Observability pipelines: PG/Kafka metrics -> Thanos -> Grafana; Service (Kafka/PG) logs -> Opensearch
* Data pipelines: "Connect Clickhouse to my Kafka service"

<img width="913" height="202" alt="Screenshot 2026-04-09 at 12 04 51" src="https://github.com/user-attachments/assets/4a9ac3ba-3aaf-4894-a1bf-a3f935417bfe" />

<img width="646" height="192" alt="Screenshot 2026-04-09 at 12 04 36" src="https://github.com/user-attachments/assets/e249eac4-3918-4882-a280-6b13fd671679" />



<!-- Provide the issue number below if it exists. -->
Resolves: EVERSQL-1760