### PR TITLE
show a warning before adding public endpoint

### DIFF
--- a/src/tools/kafka/descriptions.ts
+++ b/src/tools/kafka/descriptions.ts
@@ -14,6 +14,9 @@ Supports Debezium CDC connectors (PostgreSQL, MySQL), JDBC source/sink, and any 
 
 **IMPORTANT — topics must exist before the connector starts.** Aiven Kafka does not auto-create topics. Create all required topics using \`aiven_kafka_topic_create\` before or immediately after creating the connector. Topic naming depends on the connector type (e.g. Debezium uses \`{topic.prefix}.{schema}.{table}\`).
 
+**Assistant:** If you suggest enabling public access for Kafka (e.g. \`user_config.public_access\`), include this line for the user:
+- ⚠️ WARNING: This makes the Kafka service reachable from the internet.
+
 ${TOOL_LIST_PICKER_SUFFIX}`;
 
 export const CREATE_CONNECTOR_DESCRIPTION = `Create a Kafka Connect connector.

--- a/src/tools/pg/descriptions.ts
+++ b/src/tools/pg/descriptions.ts
@@ -19,6 +19,9 @@ Works best with SELECT queries but also helps with INSERT/UPDATE/DELETE.
 
 export const PG_READ_DESCRIPTION = `Execute a read-only SQL query against an Aiven PostgreSQL service.
 
+**Assistant:** If you suggest enabling public DB access, include this line for the user:
+- ⚠️ WARNING: This makes the database reachable from the internet.
+
 The connection is made in read-only mode with a 30-second timeout.
 Only SELECT and other read operations are allowed. INSERT, UPDATE, DELETE,
 CREATE, DROP, and other write operations will be rejected by PostgreSQL.
@@ -41,6 +44,9 @@ aiven_pg_read(project="my-project", service_name="my-pg", query="SELECT tablenam
 ${UNTRUSTED_DATA_SUFFIX}`;
 
 export const PG_WRITE_DESCRIPTION = `Execute a write SQL statement against an Aiven PostgreSQL service.
+
+**Assistant:** If you suggest enabling public DB access, include this line for the user:
+- ⚠️ WARNING: This makes the database reachable from the internet.
 
 Allows DML (INSERT, UPDATE, DELETE) and DDL (CREATE TABLE, ALTER TABLE, CREATE INDEX, etc.).
 


### PR DESCRIPTION
MCP client should show a warning when suggesting the user to create a public endpoint for some service that is running inside a vpc.

<img width="1954" height="1774" alt="image" src="https://github.com/user-attachments/assets/aed6c2ea-94dd-4b1f-add2-2811aa14d478" />
