### PR TITLE
feat: enable MCP session reuse in HTTP transport

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -24,6 +24,7 @@ interface Session {
 }
 
 const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_SESSIONS = 1000;
 
 function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   const [scheme, token] = (req.headers.authorization ?? '').split(' ', 2);
@@ -109,6 +110,12 @@ export function startHttpServer(
         return;
       } else if (isInitializeRequest(req.body)) {
         // First request — create new session
+        if (sessions.size >= MAX_SESSIONS) {
+          res.status(503).set('Retry-After', '30').json({ error: 'Too many active sessions' });
+          return;
+        }
+
+        const mcpServer = createServer();
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
           enableJsonResponse: true,
@@ -117,7 +124,6 @@ export function startHttpServer(
           },
         });
 
-        const mcpServer = createServer();
         await mcpServer.connect(transport as unknown as Transport);
 
         transport.onclose = () => {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import express from 'express';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -16,6 +17,14 @@ interface HttpServerConfig {
   scopes: string[];
 }
 
+interface Session {
+  transport: StreamableHTTPServerTransport;
+  server: McpServer;
+  createdAt: number;
+}
+
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
 function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   const [scheme, token] = (req.headers.authorization ?? '').split(' ', 2);
   if (scheme !== 'Bearer' || !token) {
@@ -26,12 +35,36 @@ function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   next();
 }
 
+// Detect MCP initialize requests (single or batched JSON-RPC)
+function isInitializeRequest(body: unknown): boolean {
+  if (Array.isArray(body)) {
+    return body.some((msg) => typeof msg === 'object' && msg !== null && 'method' in msg && msg.method === 'initialize');
+  }
+  return typeof body === 'object' && body !== null && 'method' in body && (body as { method: string }).method === 'initialize';
+}
+
 export function startHttpServer(
   createServer: () => McpServer,
   config: HttpServerConfig
 ): void {
   const app = express();
   app.use(express.json({ limit: '5mb' }));
+
+  // Reuse transport+server across requests in the same MCP session,
+  // so clients don't re-handshake (initialize + notify) on every tool call.
+  const sessions = new Map<string, Session>();
+
+  // Evict stale sessions periodically
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [id, session] of sessions) {
+      if (now - session.createdAt > SESSION_TTL_MS) {
+        session.transport.close().catch(() => {});
+        sessions.delete(id);
+      }
+    }
+  }, 60_000);
+  cleanupInterval.unref();
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });
@@ -50,16 +83,51 @@ export function startHttpServer(
     res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
   });
 
-  app.delete('/mcp', (_req: Request, res: Response) => {
-    res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
+  app.delete('/mcp', authMiddleware, (req: Request, res: Response) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (sessionId && sessions.has(sessionId)) {
+      const session = sessions.get(sessionId)!;
+      session.transport.close().catch(() => {});
+      sessions.delete(sessionId);
+    }
+    res.status(200).json({ status: 'session closed' });
   });
 
   app.post('/mcp', authMiddleware, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
       const token = (req as Request & { token: string }).token;
-      const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-      const mcpServer = createServer();
-      await mcpServer.connect(transport as unknown as Transport);
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      let transport: StreamableHTTPServerTransport;
+
+      if (sessionId && sessions.has(sessionId)) {
+        // Existing session — reuse transport (no re-init needed)
+        transport = sessions.get(sessionId)!.transport;
+      } else if (sessionId) {
+        // Session ID provided but not found (expired or wrong instance)
+        res.status(404).json({ error: 'Session not found' });
+        return;
+      } else if (isInitializeRequest(req.body)) {
+        // First request — create new session
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          enableJsonResponse: true,
+          onsessioninitialized: (newId: string) => {
+            sessions.set(newId, { transport, server: mcpServer, createdAt: Date.now() });
+          },
+        });
+
+        const mcpServer = createServer();
+        await mcpServer.connect(transport as unknown as Transport);
+
+        transport.onclose = () => {
+          const id = transport.sessionId;
+          if (id) sessions.delete(id);
+        };
+      } else {
+        res.status(400).json({ error: 'Bad Request: missing session ID or not an initialize request' });
+        return;
+      }
 
       (req as Request & { auth: { token: string; clientId: string; scopes: string[] } }).auth = {
         token,


### PR DESCRIPTION
Made-with: Cursor

# About this change - What it does
Switched from stateless MCP (new server + transport per request) to stateful sessions using Mcp-Session-Id (part of the MCP SDK protocol), reusing the same transport/server.

## Impact
* Reduced MCP POST calls from 3N → 2+N (~67% fewer overhead requests)
* Saved ~257ms round-trip latency per tool call
* Eliminated repeated initialize + initialized handshakes on every call

<img width="740" height="333" alt="Screenshot 2026-04-15 at 14 15 29" src="https://github.com/user-attachments/assets/e84aa18b-582c-46c0-b1cb-2876829a841a" />

## Important note
Sessions are currently in-memory. For multi-node deployments, we need either:
* Sticky sessions (based on Mcp-Session-Id), or
* External session store (e.g. Valkey)


Resolves: EVERSQL-1774