### PR TITLE
mcp: add rate limit to /mcp endpoint [EVERSQL-1789]

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.2",
     "libpg-query": "^17.7.3",
     "openapi-fetch": "^0.17.0",
     "pg": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.3.2
+        version: 8.3.2(express@5.2.1)
       libpg-query:
         specifier: ^17.7.3
         version: 17.7.3
@@ -1033,8 +1036,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.2.1:
-    resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -1193,8 +1196,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2114,7 +2117,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
+      express-rate-limit: 8.3.2(express@5.2.1)
       hono: 4.11.7
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -2759,10 +2762,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.2.1(express@5.2.1):
+  express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.0.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -2931,7 +2934,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.0.1: {}
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,32 @@ export const API_ORIGIN = process.env['AIVEN_API_ORIGIN'] ?? 'https://api.aiven.
 export const API_BASE_URL = `${API_ORIGIN}/v1`;
 export const HOST = 'https://mcp.aiven.live'
 
+/** HTTP POST /mcp rate limit (per bearer token hash, else per client IP). */
+export interface HttpMcpRateLimitConfig {
+  windowMs: number;
+  limit: number;
+}
+
+function parsePositiveIntEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : defaultValue;
+}
+
+export function loadHttpMcpRateLimit(): HttpMcpRateLimitConfig {
+  return {
+    windowMs: parsePositiveIntEnv('MCP_HTTP_RATE_LIMIT_WINDOW_MS', 60_000),
+    limit: parsePositiveIntEnv('MCP_HTTP_RATE_LIMIT_MAX', 100),
+  };
+}
+
+/** When true, Express honors X-Forwarded-For for req.ip (use behind a reverse proxy). */
+export function httpTrustProxyEnabled(): boolean {
+  const v = process.env['MCP_TRUST_PROXY'];
+  return v === '1' || v === 'true';
+}
+
 export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
   const token = process.env['AIVEN_TOKEN'];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { createPgCustomTools } from './tools/pg/index.js';
 import { createApplicationTools } from './tools/applications/index.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
 import type { ToolDefinition } from './types.js';
-import { VERSION, API_ORIGIN } from './config.js';
+import { VERSION, API_ORIGIN, loadHttpMcpRateLimit, httpTrustProxyEnabled } from './config.js';
 import { READ_ONLY_INSTRUCTIONS } from './prompts.js';
 
 /** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
@@ -82,6 +82,8 @@ async function main(): Promise<void> {
       port: parseInt(process.env['PORT'] ?? '3000', 10),
       apiOrigin: API_ORIGIN,
       scopes: ['projects', 'services', 'accounts:read'],
+      rateLimit: loadHttpMcpRateLimit(),
+      trustProxy: httpTrustProxyEnabled(),
     });
   } else {
     const server = createMcpServer();

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,10 +1,13 @@
+import { createHash } from 'node:crypto';
 import express from 'express';
+import rateLimit, { ipKeyGenerator, type Options } from 'express-rate-limit';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Request, Response, NextFunction } from 'express';
 import { HOST } from './config.js';
+import type { HttpMcpRateLimitConfig } from './config.js';
 
 export function createStdioTransport(): StdioServerTransport {
   return new StdioServerTransport();
@@ -14,6 +17,49 @@ interface HttpServerConfig {
   port: number;
   apiOrigin: string;
   scopes: string[];
+  rateLimit: HttpMcpRateLimitConfig;
+  trustProxy: boolean;
+}
+
+const RATE_LIMIT_PROPERTY = 'rateLimit' as const;
+
+/** Logs and sends the same response as express-rate-limit's default handler. */
+function rateLimitExceededHandler(scope: string) {
+  return (request: Request, response: Response, _next: NextFunction, optionsUsed: Options): void => {
+    const rl = (request as Request & { [RATE_LIMIT_PROPERTY]?: { limit: number; used: number; key: string } })[
+      RATE_LIMIT_PROPERTY
+    ];
+    const ip = request.ip ?? 'unknown';
+    const path = request.path || request.url || '';
+    console.warn(
+      `mcp-aiven: rate limit exceeded (${scope}) ${request.method} ${path} ip=${ip}` +
+        (rl !== undefined ? ` limit=${rl.limit} used=${rl.used} keyPrefix=${rl.key.slice(0, 8)}` : '')
+    );
+    response.status(optionsUsed.statusCode);
+    const message = optionsUsed.message;
+    if (typeof message === 'function') {
+      void Promise.resolve(message(request, response)).then((body) => {
+        if (!response.writableEnded) response.send(body);
+      });
+    } else if (!response.writableEnded) {
+      response.send(message);
+    }
+  };
+}
+
+function createMcpPostRateLimit(
+  cfg: HttpMcpRateLimitConfig,
+  message: { error: string }
+): ReturnType<typeof rateLimit> {
+  return rateLimit({
+    windowMs: cfg.windowMs,
+    limit: cfg.limit,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    keyGenerator: (req: Request) => mcpRequestKey(req),
+    message,
+    handler: rateLimitExceededHandler('mcp-post'),
+  });
 }
 
 function authMiddleware(req: Request, res: Response, next: NextFunction): void {
@@ -26,12 +72,30 @@ function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   next();
 }
 
+function mcpRequestKey(req: Request): string {
+  const auth = req.headers.authorization;
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+    const token = auth.slice(7).trim();
+    if (token.length > 0) {
+      return createHash('sha256').update(token).digest('hex');
+    }
+  }
+  return ipKeyGenerator(req.ip ?? '0.0.0.0');
+}
+
 export function startHttpServer(
   createServer: () => McpServer,
   config: HttpServerConfig
 ): void {
   const app = express();
+  if (config.trustProxy) {
+    app.set('trust proxy', 1);
+  }
   app.use(express.json({ limit: '5mb' }));
+
+  const mcpPostRateLimit = createMcpPostRateLimit(config.rateLimit, {
+    error: 'Too many MCP requests. Please wait before trying again.',
+  });
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });
@@ -54,13 +118,12 @@ export function startHttpServer(
     res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
   });
 
-  app.post('/mcp', authMiddleware, (req: Request, res: Response) => {
+  app.post('/mcp', mcpPostRateLimit, authMiddleware, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
       const token = (req as Request & { token: string }).token;
       const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
       const mcpServer = createServer();
       await mcpServer.connect(transport as unknown as Transport);
-
       (req as Request & { auth: { token: string; clientId: string; scopes: string[] } }).auth = {
         token,
         clientId: 'aiven',

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadConfig } from '../../src/config.js';
+import { loadConfig, loadHttpMcpRateLimit, httpTrustProxyEnabled } from '../../src/config.js';
 
 describe('loadConfig', () => {
   const originalEnv = process.env;
@@ -69,5 +69,62 @@ describe('loadConfig', () => {
     const config = loadConfig();
 
     expect(config.readOnly).toBe(false);
+  });
+});
+
+describe('loadHttpMcpRateLimit', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['MCP_HTTP_RATE_LIMIT_WINDOW_MS'];
+    delete process.env['MCP_HTTP_RATE_LIMIT_MAX'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should use defaults when env is unset', () => {
+    expect(loadHttpMcpRateLimit()).toEqual({ windowMs: 60_000, limit: 100 });
+  });
+
+  it('should read MCP_HTTP_RATE_LIMIT_WINDOW_MS and MCP_HTTP_RATE_LIMIT_MAX', () => {
+    process.env['MCP_HTTP_RATE_LIMIT_WINDOW_MS'] = '30000';
+    process.env['MCP_HTTP_RATE_LIMIT_MAX'] = '60';
+
+    expect(loadHttpMcpRateLimit()).toEqual({ windowMs: 30_000, limit: 60 });
+  });
+
+  it('should fall back to defaults for invalid env values', () => {
+    process.env['MCP_HTTP_RATE_LIMIT_WINDOW_MS'] = '0';
+    process.env['MCP_HTTP_RATE_LIMIT_MAX'] = '-1';
+
+    expect(loadHttpMcpRateLimit()).toEqual({ windowMs: 60_000, limit: 100 });
+  });
+});
+
+describe('httpTrustProxyEnabled', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['MCP_TRUST_PROXY'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should be false when MCP_TRUST_PROXY is unset', () => {
+    expect(httpTrustProxyEnabled()).toBe(false);
+  });
+
+  it('should be true when MCP_TRUST_PROXY is 1 or true', () => {
+    process.env['MCP_TRUST_PROXY'] = '1';
+    expect(httpTrustProxyEnabled()).toBe(true);
+
+    process.env['MCP_TRUST_PROXY'] = 'true';
+    expect(httpTrustProxyEnabled()).toBe(true);
   });
 });

--- a/tests/runtime/pg.test.ts
+++ b/tests/runtime/pg.test.ts
@@ -761,13 +761,13 @@ describe('aiven_pg_read', () => {
     const tools = createPgCustomTools(client);
     const tool = getPgQueryTool(tools);
 
-    // Fire 30 queries (the limit)
-    for (let i = 0; i < 30; i++) {
+    // Fire 100 queries (the limit; see RATE_LIMIT_MAX in query.ts)
+    for (let i = 0; i < 100; i++) {
       const r = await tool.handler({ project: 'proj', service_name: 'svc', query: 'SELECT 1' });
       expect(r.isError).toBeUndefined();
     }
 
-    // The 31st should be rejected
+    // The 101st should be rejected
     const result = await tool.handler({ project: 'proj', service_name: 'svc', query: 'SELECT 1' });
     expect(result.isError).toBe(true);
     expect(firstTextContent(result.content)).toContain('Rate limit exceeded');
@@ -781,7 +781,7 @@ describe('aiven_pg_read', () => {
     const tool = getPgQueryTool(tools);
 
     // Exhaust the limit
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < 100; i++) {
       await tool.handler({ project: 'proj', service_name: 'svc', query: 'SELECT 1' });
     }
 
@@ -1377,28 +1377,28 @@ describe('aiven_pg_write', () => {
     const readTool = getPgQueryTool(tools);
     const writeTool = getPgExecuteQueryTool(tools);
 
-    // Fire 29 read queries
-    for (let i = 0; i < 29; i++) {
+    // Fire 99 read queries
+    for (let i = 0; i < 99; i++) {
       const r = await readTool.handler({ project: 'proj', service_name: 'svc', query: 'SELECT 1' });
       expect(r.isError).toBeUndefined();
     }
 
-    // 1 write query (30th total)
-    const r30 = await writeTool.handler({
+    // 1 write query (100th total)
+    const r100 = await writeTool.handler({
       project: 'proj',
       service_name: 'svc',
       query: "INSERT INTO users (name) VALUES ('test')",
     });
-    expect(r30.isError).toBeUndefined();
+    expect(r100.isError).toBeUndefined();
 
-    // 31st query (write) should be rate-limited
-    const r31 = await writeTool.handler({
+    // 101st query (write) should be rate-limited
+    const r101 = await writeTool.handler({
       project: 'proj',
       service_name: 'svc',
       query: "INSERT INTO users (name) VALUES ('test2')",
     });
-    expect(r31.isError).toBe(true);
-    expect(firstTextContent(r31.content)).toContain('Rate limit exceeded');
+    expect(r101.isError).toBe(true);
+    expect(firstTextContent(r101.content)).toContain('Rate limit exceeded');
   });
 
   it('should handle errors and rollback', async () => {


### PR DESCRIPTION
[[JIRA](https://aiven.atlassian.net/jira/software/c/projects/EVERSQL/boards/234?assignee=712020%3Aca98ee31-fdc0-419a-8263-6afed86dfad6&selectedIssue=EVERSQL-1789)]

- HTTP transport rate limit - per-client POST /mcp (MCP_HTTP_RATE_LIMIT_*): per Bearer token or
  fallback per IP.
- Log a warning when rate limit is hit.
- Small fix in pg test file