### PR TITLE
feat: add observability headers and reasoning field to all tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ OAUTH_PLAN.md
 .cache/
 generator/schemas/
 src/generated/
+.claude/settings.local.json
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -102,13 +102,30 @@ Config file locations:
 - Cursor: Cursor Settings > MCP Servers
 - VS Code: `.vscode/mcp.json` in your workspace
 
+### Option 3: Local development
+
+Run a local build of the server (useful for development and testing):
+
+```bash
+pnpm install && pnpm generate:api-types && pnpm generate && pnpm build && AIVEN_TOKEN="<YOUR_TOKEN>" MCP_TRANSPORT="http" PORT=3000 node dist/index.js
+```
+
+The server listens on port 3000 by default. Connect your MCP client to `http://localhost:3000/mcp`.
+
+To point a remote deployment at a custom host (e.g. your local build), set `MCP_HOST`:
+
+```bash
+MCP_HOST=http://localhost:3000 node dist/index.js
+```
+
 ### Environment Variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `AIVEN_TOKEN` | stdio only | -- | Aiven API token ([create one here](https://console.aiven.io/profile/tokens)) |
 | `AIVEN_READ_ONLY` | No | `false` | Set to `true` to expose only read-only tools |
-| `MCP_HOST` | No | `https://mcp.aiven.live` | Public base URL of this server, advertised in OAuth protected resource metadata. Override when deploying behind a custom domain. |
+| `MCP_HOST` | No | `https://mcp.aiven.live` | Override the OAuth protected resource host |
+| `MCP_TRANSPORT` | No | `stdio` | Set to `http` to start an HTTP server instead of stdio |
 
 In remote (HTTP) mode, `AIVEN_TOKEN` is not needed. Your MCP client sends your token as a Bearer token with each request.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -96,6 +96,12 @@ export class AivenClient {
     if (options?.mcpClient) {
       headers['X-MCP-Client'] = options.mcpClient;
     }
+    if (options?.requestId) {
+      headers['X-MCP-Request-ID'] = options.requestId;
+    }
+    if (options?.toolReasoning) {
+      headers['X-MCP-Tool-Reasoning'] = options.toolReasoning;
+    }
     return headers;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ const pkg = require('../package.json') as { version: string };
 export const VERSION = pkg.version;
 export const API_ORIGIN = process.env['AIVEN_API_ORIGIN'] ?? 'https://api.aiven.io';
 export const API_BASE_URL = `${API_ORIGIN}/v1`;
-export const HOST = process.env['MCP_HOST'] ?? 'https://mcp.aiven.live'
+export const HOST = process.env['MCP_HOST'] ?? 'https://mcp.aiven.live';
 
 /** HTTP POST /mcp rate limit (per bearer token hash, else per client IP). */
 export interface HttpMcpRateLimitConfig {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { createDocsTools } from './tools/docs/index.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
 import type { ToolDefinition, McpRequestOptions } from './types.js';
 import { VERSION, API_ORIGIN, loadHttpMcpRateLimit, httpTrustProxyEnabled } from './config.js';
+import { READ_ONLY_INSTRUCTIONS } from './prompts.js';
+import { createObservabilityContext } from './observability.js';
 import { readOnlyInstructions } from './prompts.js';
 
 /** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
@@ -47,10 +49,17 @@ function registerTools(server: McpServer, tools: readonly ToolDefinition[]): voi
         ...(tool.definition.outputSchema ? { outputSchema: tool.definition.outputSchema } : {}),
       },
       async (params, extra) => {
+        const paramsObj = params as Record<string, unknown>;
+        const reasoning = paramsObj['reasoning'] as string | undefined;
+        const obsContext = createObservabilityContext(reasoning);
+
         const context = {
           token: extra.authInfo?.token,
           mcpClient: mcpClientFromRequestInfo(extra.requestInfo) ?? server.server.getClientVersion()?.name,
+          requestId: obsContext.requestId,
+          toolReasoning: obsContext.toolReasoning,
         };
+
         return tool.handler(params, context);
       }
     );

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,34 @@
+import { randomUUID } from 'node:crypto';
+import { redactSensitiveData } from './security.js';
+
+export function generateRequestId(): string {
+  return randomUUID();
+}
+
+export function redactReasoningField(reasoning: unknown): string | null {
+  if (reasoning === undefined || reasoning === null) {
+    return null;
+  }
+  if (typeof reasoning !== 'string') {
+    const stringified = String(reasoning);
+    const wrapped = { reasoning: stringified };
+    const redacted = redactSensitiveData(wrapped) as { reasoning: string };
+    return redacted.reasoning;
+  }
+  if (reasoning.length === 0) {
+    return reasoning;
+  }
+  const wrapped = { reasoning };
+  const redacted = redactSensitiveData(wrapped) as { reasoning: string };
+  return redacted.reasoning;
+}
+
+export function createObservabilityContext(reasoning?: string): {
+  requestId: string;
+  toolReasoning: string | null;
+} {
+  return {
+    requestId: generateRequestId(),
+    toolReasoning: redactReasoningField(reasoning),
+  };
+}

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -1,6 +1,6 @@
 import type { AivenClient } from '../client.js';
 import type { ToolDefinition, ToolResult, HandlerContext, ApiToolConfig, RequestOptions } from '../types.js';
-import { toolSuccess, toolError } from '../types.js';
+import { toolSuccess, toolErrorWithRequestId } from '../types.js';
 import { errorMessage } from '../errors.js';
 import { redactSensitiveData } from '../security.js';
 import { wrapUntrustedResponse } from '../untrusted.js';
@@ -87,13 +87,17 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
       try {
         const args = params as Record<string, unknown>;
+        const { reasoning, ...argsWithoutReasoning } = args;
+
         const opts: RequestOptions = {
           token: context?.token,
           mcpClient: context?.mcpClient,
           toolName: config.name,
+          requestId: context?.requestId,
+          toolReasoning: context?.toolReasoning,
         };
 
-        const data = await executeRequest(client, config, args, pathParams, opts);
+        const data = await executeRequest(client, config, argsWithoutReasoning, pathParams, opts);
 
         const filtered = config.responseFilter
           ? applyResponseFilter(data, config.responseFilter)
@@ -101,7 +105,7 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
 
         return toolSuccess(wrapUntrustedResponse(redactSensitiveData(filtered)));
       } catch (err) {
-        return toolError(errorMessage(err));
+        return toolErrorWithRequestId(errorMessage(err), context?.requestId);
       }
     },
   };

--- a/src/tools/applications/handlers.ts
+++ b/src/tools/applications/handlers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { AivenClient } from '../../client.js';
-import type { ToolDefinition, ToolResult, HandlerContext } from '../../types.js';
+import type { ToolDefinition, ToolResult, HandlerContext, RequestOptions } from '../../types.js';
 import {
   ServiceCategory,
   ApplicationToolName,
@@ -9,6 +9,7 @@ import {
   READ_ONLY_ANNOTATIONS,
   toolSuccess,
   toolError,
+  toolErrorWithRequestId,
 } from '../../types.js';
 import { errorMessage } from '../../errors.js';
 import { redactSensitiveData } from '../../security.js';
@@ -265,7 +266,11 @@ CMD ["node", "dist/index.js"]
         };
 
         try {
-          const opts = context?.token ? { token: context.token } : undefined;
+          const opts: RequestOptions = {
+            token: context?.token,
+            requestId: context?.requestId,
+            toolReasoning: context?.toolReasoning,
+          };
           const result = await client.post<Record<string, unknown>>(
             `/project/${encodeURIComponent(project)}/service`,
             data,
@@ -286,7 +291,7 @@ CMD ["node", "dist/index.js"]
 
           return toolSuccess(wrapUntrustedResponse(redactSensitiveData(result)));
         } catch (err) {
-          return toolError(errorMessage(err));
+          return toolErrorWithRequestId(errorMessage(err), context?.requestId);
         }
       },
     },
@@ -313,14 +318,19 @@ The rebuild pulls the latest commit from the configured branch and rebuilds the 
         annotations: UPDATE_ANNOTATIONS,
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
-        const { project, service_name: serviceName } = params as z.infer<typeof redeployApplicationInput>;
+        const { project, service_name: serviceName } = params as z.infer<
+          typeof redeployApplicationInput
+        >;
 
         try {
-          const opts = context?.token ? { token: context.token } : undefined;
+          const opts: RequestOptions = {
+            token: context?.token,
+            requestId: context?.requestId,
+            toolReasoning: context?.toolReasoning,
+          };
 
-          // No dedicated redeploy endpoint exists yet. A no-op service update (empty PUT body)
-          // triggers Meta Core's Executor to pick up the change and redeploy — same mechanism
-          // used by the Aiven Console redeploy button.
+          // A no-op service update (empty PUT body) triggers a redeploy — same
+          // mechanism used by the Aiven Console redeploy button.
           await client.put<Record<string, unknown>>(
             `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}`,
             {},
@@ -332,7 +342,7 @@ The rebuild pulls the latest commit from the configured branch and rebuilds the 
             message: 'Redeploy triggered. The service will pull latest code, rebuild, and deploy.',
           });
         } catch (err) {
-          return toolError(errorMessage(err));
+          return toolErrorWithRequestId(errorMessage(err), context?.requestId);
         }
       },
     },
@@ -351,7 +361,7 @@ Returns each integration's \`vcs_integration_id\` (needed for \`aiven_vcs_integr
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         const { project } = params as z.infer<typeof vcsIntegrationListInput>;
-        const opts = context?.token ? { token: context.token } : undefined;
+        const opts = { token: context?.token, requestId: context?.requestId, toolReasoning: context?.toolReasoning };
 
         let organizationId: string;
         try {
@@ -403,7 +413,7 @@ Returns \`remote_repository_id\`, \`full_name\`, \`source_url\`, and \`default_b
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         const { organization_id: organizationId, vcs_integration_id: vcsIntegrationId } =
           params as z.infer<typeof vcsIntegrationRepositoryListInput>;
-        const opts = context?.token ? { token: context.token } : undefined;
+        const opts = { token: context?.token, requestId: context?.requestId, toolReasoning: context?.toolReasoning };
 
         try {
           type RepoRow = {

--- a/src/tools/applications/schemas.ts
+++ b/src/tools/applications/schemas.ts
@@ -243,6 +243,8 @@ export const deployApplicationInput = z
           'and you must specify one. In that case, call aiven_project_vpc_list to list available VPCs ' +
           'and ask the user which to use.'
       ),
+
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();
 
@@ -250,6 +252,7 @@ export const redeployApplicationInput = z
   .object({
     project: z.string().describe('Aiven project name'),
     service_name: z.string().describe('Name of the existing application service to redeploy'),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();
 
@@ -260,6 +263,7 @@ export const vcsIntegrationListInput = z
       .describe(
         'Aiven project name. The organization_id is resolved internally from this project.'
       ),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();
 
@@ -275,5 +279,6 @@ export const vcsIntegrationRepositoryListInput = z
       .describe(
         'VCS integration ID returned by aiven_vcs_integration_list (e.g. "vcs-abc123").'
       ),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();

--- a/src/tools/kafka/handlers.ts
+++ b/src/tools/kafka/handlers.ts
@@ -7,7 +7,7 @@ import {
   CREATE_ANNOTATIONS,
   UPDATE_ANNOTATIONS,
   toolSuccess,
-  toolError,
+  toolErrorWithRequestId,
 } from '../../types.js';
 import { errorMessage } from '../../errors.js';
 import { redactSensitiveData } from '../../security.js';
@@ -15,6 +15,7 @@ import { wrapUntrustedResponse } from '../../untrusted.js';
 import { buildConnectorConfig } from './helpers.js';
 import { createConnectorInput, editConnectorInput } from './schemas.js';
 import { CREATE_CONNECTOR_DESCRIPTION, EDIT_CONNECTOR_DESCRIPTION } from './descriptions.js';
+import type { RequestOptions } from '../../types.js';
 
 export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
   return [
@@ -33,10 +34,12 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
             Record<string, unknown>;
           const { project, service_name: serviceName } = typedParams;
 
-          const opts = {
+          const opts: RequestOptions = {
             token: context?.token,
             mcpClient: context?.mcpClient,
             toolName: KafkaToolName.ConnectCreateConnector,
+            requestId: context?.requestId,
+            toolReasoning: context?.toolReasoning,
           };
           const config = await buildConnectorConfig(client, typedParams, opts);
 
@@ -48,7 +51,7 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
 
           return toolSuccess(wrapUntrustedResponse(redactSensitiveData(data)));
         } catch (err) {
-          return toolError(errorMessage(err));
+          return toolErrorWithRequestId(errorMessage(err), context?.requestId);
         }
       },
     },
@@ -67,10 +70,12 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
           const typedParams = params as z.infer<typeof editConnectorInput> & Record<string, unknown>;
           const { project, service_name: serviceName, connector_name: connectorName } = typedParams;
 
-          const opts = {
+          const opts: RequestOptions = {
             token: context?.token,
             mcpClient: context?.mcpClient,
             toolName: KafkaToolName.ConnectEditConnector,
+            requestId: context?.requestId,
+            toolReasoning: context?.toolReasoning,
           };
           const config = await buildConnectorConfig(client, typedParams, opts);
 
@@ -82,7 +87,7 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
 
           return toolSuccess(wrapUntrustedResponse(redactSensitiveData(data)));
         } catch (err) {
-          return toolError(errorMessage(err));
+          return toolErrorWithRequestId(errorMessage(err), context?.requestId);
         }
       },
     },

--- a/src/tools/kafka/schemas.ts
+++ b/src/tools/kafka/schemas.ts
@@ -11,6 +11,7 @@ export const createConnectorInput = z
     connector_class: z.string().describe('Java class for the connector'),
     name: z.string().describe('Unique name for the connector'),
     source_service: z.string().optional().describe(SOURCE_SERVICE_DESC),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .passthrough();
 
@@ -22,5 +23,6 @@ export const editConnectorInput = z
     connector_class: z.string().describe('Java class for the connector'),
     name: z.string().describe('Unique name for the connector'),
     source_service: z.string().optional().describe(SOURCE_SERVICE_DESC),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .passthrough();

--- a/src/tools/pg/handlers.ts
+++ b/src/tools/pg/handlers.ts
@@ -40,6 +40,8 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
             token: context?.token,
             mcpClient: context?.mcpClient,
             toolName: PgToolName.OptimizeQuery,
+            requestId: context?.requestId,
+            toolReasoning: context?.toolReasoning,
           };
           const data = await client.post<Record<string, unknown>>(
             `/account/${typedParams.account_id}/pg/query/optimize`,
@@ -82,6 +84,8 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
           token: context?.token,
           mcpClient: context?.mcpClient,
           toolName: PgToolName.Read,
+          requestId: context?.requestId,
+          toolReasoning: context?.toolReasoning,
         });
       },
     },
@@ -111,6 +115,8 @@ export function createPgCustomTools(client: AivenClient): ToolDefinition[] {
           token: context?.token,
           mcpClient: context?.mcpClient,
           toolName: PgToolName.Write,
+          requestId: context?.requestId,
+          toolReasoning: context?.toolReasoning,
         });
       },
     },

--- a/src/tools/pg/query.ts
+++ b/src/tools/pg/query.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { AivenClient } from '../../client.js';
 import type { ToolResult, ExecutePgQueryOptions } from '../../types.js';
-import { PgQueryMode, toolSuccess, toolError } from '../../types.js';
+import { PgQueryMode, toolSuccess, toolError, toolErrorWithRequestId } from '../../types.js';
 import { errorMessage } from '../../errors.js';
 import { redactSensitiveData } from '../../security.js';
 import { wrapUntrustedResponse } from '../../untrusted.js';
@@ -97,13 +97,19 @@ export async function executePgQuery(
   const rateLimitError = checkRateLimit(token);
   if (rateLimitError) return toolError(rateLimitError);
 
-  const apiOpts = { token, mcpClient: options.mcpClient, toolName: options.toolName };
+  const apiOpts = {
+    token,
+    mcpClient: options.mcpClient,
+    toolName: options.toolName,
+    requestId: options.requestId,
+    toolReasoning: options.toolReasoning,
+  };
 
   let pgClient;
   try {
     pgClient = await connectToService(client, project, service_name, database, apiOpts);
   } catch (err) {
-    return toolError(errorMessage(err));
+    return toolErrorWithRequestId(errorMessage(err), options.requestId);
   }
 
   try {
@@ -135,7 +141,7 @@ export async function executePgQuery(
     return toolSuccess(wrapInBoundary({ meta, rows: truncatedRows }));
   } catch (err: unknown) {
     await pgClient.query('ROLLBACK').catch(() => {});
-    return toolError(sanitizePgError(err));
+    return toolErrorWithRequestId(sanitizePgError(err), options.requestId);
   } finally {
     await pgClient.end();
   }

--- a/src/tools/pg/schemas.ts
+++ b/src/tools/pg/schemas.ts
@@ -13,6 +13,7 @@ export const optimizeQueryInput = z
       .enum(['18', '17', '16', '15', '14', '13', '12', '11', '10', '9'])
       .default('16')
       .describe('PostgreSQL version'),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();
 
@@ -46,6 +47,7 @@ export const pgQueryInput = z
       .describe(
         'Number of rows to skip before returning results (default: 0). Use with limit for pagination.'
       ),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();
 
@@ -79,5 +81,6 @@ export const pgExecuteQueryInput = z
       .describe(
         'Number of rows to skip before returning results (default: 0). Use with limit for pagination.'
       ),
+    reasoning: z.string().min(1).describe('Brief explanation of why you are making this call. Used for audit logs and debugging.'),
   })
   .strict();

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,8 @@ export interface RequestOptions {
   token?: string | undefined;
   toolName?: string | undefined;
   mcpClient?: string | undefined;
+  requestId?: string | undefined;
+  toolReasoning?: string | null | undefined;
 }
 
 export interface ToolAnnotations {
@@ -79,6 +81,8 @@ export type ToolResult = CallToolResult;
 export interface HandlerContext {
   token?: string | undefined;
   mcpClient?: string | undefined;
+  requestId?: string | undefined;
+  toolReasoning?: string | null | undefined;
 }
 
 export interface ToolDefinition<TInput extends z.ZodType = z.ZodType> {
@@ -111,6 +115,13 @@ export function toolError(message: string): ToolResult {
     content: [textContent(message)],
     isError: true,
   };
+}
+
+export function toolErrorWithRequestId(message: string, requestId?: string): ToolResult {
+  const text = requestId
+    ? `${message}\nRequest ID: ${requestId} (share this for support)`
+    : message;
+  return toolError(text);
 }
 
 export interface JsonSchema {
@@ -183,6 +194,8 @@ export interface ExecutePgQueryOptions {
   token?: string | undefined;
   mcpClient?: string | undefined;
   toolName?: string | undefined;
+  requestId?: string | undefined;
+  toolReasoning?: string | null | undefined;
 }
 
 // ---------- Application ----------


### PR DESCRIPTION
[Jira](https://aiven.atlassian.net/browse/EVERSQL-1806)


Add per-call request ID (X-MCP-Request-ID) and model reasoning (X-MCP-Tool-Reasoning) headers to every Aiven API request, flowing through the existing X-MCP-* header pipeline to Acorn/analytics.

- Add required `reasoning` field to all tool schemas so the model explains its intent on every call
- Generate UUID per tool call, propagate via X-MCP-Request-ID header
- Include request ID in error responses for user support correlation
- Strip `reasoning` from args before passing to business logic
- Redact reasoning field using existing sensitive data patterns
- Make HOST configurable via MCP_HOST env var
- Add toolErrorWithRequestId() helper to reduce error handling duplication

<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->