### PR TITLE
feat: stamp origin tag on services created via mcp-aiven

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Config file locations:
 
 In remote (HTTP) mode, `AIVEN_TOKEN` is not needed. Your MCP client sends your token as a Bearer token with each request.
 
+## AI origin tagging
+
+Services created by `aiven_service_create` and `aiven_application_deploy` are stamped with an `origin: mcp-aiven` tag so you can filter resources that came from this MCP server.
+
+- User-supplied tags are preserved; a caller-set `origin` value is never overwritten.
+- The `origin` key is meant to be shared with other AI-driven Aiven tooling (skills bundle, future MCPs) using different values (e.g. `skill-cli`, `skill-mcp`).
+
 ## Tools
 
 ### Core

--- a/src/shared/ai-tags.ts
+++ b/src/shared/ai-tags.ts
@@ -1,0 +1,33 @@
+/**
+ * AI origin tagging for resources created via mcp-aiven.
+ *
+ * Every Aiven service created through this server is tagged with `origin`
+ * so resources can be filtered by their AI source. The same key is intended
+ * to be reused by other AI-driven Aiven tooling (skills bundle, future MCPs)
+ * with different values (e.g. `skill-cli`, `skill-mcp`).
+ *
+ * Tag constraints (see `aiven-core/aiven/web/schema.py`):
+ *   - Key matches `^[a-zA-Z][a-zA-Z0-9_-]*(:[a-zA-Z][a-zA-Z0-9_-]*)?$`,
+ *     length 1-64. The `aiven:` namespace is forbidden.
+ *   - Value is a string up to 64 chars.
+ *   - At most 25 tags per resource.
+ */
+
+export const AI_ORIGIN_TAG_KEY = 'origin';
+export const AI_ORIGIN_TAG_VALUE = 'mcp-aiven';
+
+/**
+ * Returns a new request body with `tags['origin']` set to the configured
+ * AI origin value. Existing tags are preserved, and a caller-supplied
+ * `origin` value is never overwritten.
+ */
+export function withOriginTag(
+  body: Record<string, unknown>
+): Record<string, unknown> {
+  const existing = (body['tags'] as Record<string, string> | undefined) ?? {};
+  if (AI_ORIGIN_TAG_KEY in existing) return body;
+  return {
+    ...body,
+    tags: { ...existing, [AI_ORIGIN_TAG_KEY]: AI_ORIGIN_TAG_VALUE },
+  };
+}

--- a/src/tools/applications/handlers.ts
+++ b/src/tools/applications/handlers.ts
@@ -13,6 +13,7 @@ import {
 import { errorMessage } from '../../errors.js';
 import { redactSensitiveData } from '../../security.js';
 import { getProjectCaCert } from '../../shared/service-info.js';
+import { withOriginTag } from '../../shared/ai-tags.js';
 import {
   deployApplicationInput,
   redeployApplicationInput,
@@ -251,7 +252,7 @@ CMD ["node", "dist/index.js"]
           environment_variables: allEnvVars,
         };
 
-        const data = {
+        const data = withOriginTag({
           service_name: serviceName,
           service_type: 'application',
           plan,
@@ -261,7 +262,7 @@ CMD ["node", "dist/index.js"]
           user_config: {
             application: applicationConfig,
           },
-        };
+        });
 
         try {
           const opts = context?.token ? { token: context.token } : undefined;

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -22,6 +22,7 @@ import { jsonSchemaToZod } from './json-schema-to-zod.js';
 import { createApiTool } from './api-tool.js';
 import { createRequire } from 'node:module';
 import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
+import { withOriginTag } from '../shared/ai-tags.js';
 
 interface ManifestEntry {
   name: string;
@@ -175,12 +176,13 @@ export function loadApiTools(client: AivenClient): ToolDefinition[] {
       client
     );
 
-    // Resolve free plan cloud for aiven_service_create
+    // Resolve free plan cloud and stamp the AI origin tag for aiven_service_create.
     if (entry.name === 'aiven_service_create') {
       const originalHandler = tool.handler;
       tool.handler = async (params, context?: HandlerContext): Promise<ToolResult> => {
         const args = params as Record<string, unknown>;
         await resolveFreePlanCloud(args, client, context?.token);
+        args['tags'] = withOriginTag(args)['tags'];
         return originalHandler(params, context);
       };
     }

--- a/tests/runtime/ai-tags.test.ts
+++ b/tests/runtime/ai-tags.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AI_ORIGIN_TAG_KEY,
+  AI_ORIGIN_TAG_VALUE,
+  withOriginTag,
+} from '../../src/shared/ai-tags.js';
+import { loadApiTools } from '../../src/tools/registry.js';
+import { createApplicationTools } from '../../src/tools/applications/index.js';
+import { ApplicationToolName } from '../../src/types.js';
+import type { AivenClient } from '../../src/client.js';
+import type { ToolDefinition } from '../../src/types.js';
+
+describe('withAiOriginTag', () => {
+  it('adds the origin tag when the body has no tags', () => {
+    const body = { service_name: 'svc', plan: 'startup-4' };
+    const out = withOriginTag(body);
+
+    expect(out['tags']).toEqual({ [AI_ORIGIN_TAG_KEY]: AI_ORIGIN_TAG_VALUE });
+    expect(out['service_name']).toBe('svc');
+    expect(out['plan']).toBe('startup-4');
+  });
+
+  it('preserves user-supplied tags and merges the origin tag', () => {
+    const body = {
+      service_name: 'svc',
+      tags: { team: 'platform', env: 'prod' },
+    };
+    const out = withOriginTag(body);
+
+    expect(out['tags']).toEqual({
+      team: 'platform',
+      env: 'prod',
+      [AI_ORIGIN_TAG_KEY]: AI_ORIGIN_TAG_VALUE,
+    });
+  });
+
+  it('never overwrites a caller-provided origin value', () => {
+    const body = {
+      tags: { [AI_ORIGIN_TAG_KEY]: 'caller-supplied', team: 'platform' },
+    };
+    const out = withOriginTag(body);
+
+    expect(out['tags']).toEqual({
+      [AI_ORIGIN_TAG_KEY]: 'caller-supplied',
+      team: 'platform',
+    });
+  });
+});
+
+interface MockClient {
+  client: AivenClient;
+  request: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+}
+
+function createMockClient(): MockClient {
+  const request = vi.fn().mockResolvedValue({});
+  const post = vi.fn().mockResolvedValue({ service: { service_name: 'app' } });
+  const get = vi.fn().mockResolvedValue({});
+
+  const client = {
+    request,
+    post,
+    get,
+    put: vi.fn().mockResolvedValue({}),
+    delete: vi.fn().mockResolvedValue({}),
+  } as unknown as AivenClient;
+
+  return { client, request, post, get };
+}
+
+function findTool(tools: ToolDefinition[], name: string): ToolDefinition {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`tool not found: ${name}`);
+  return tool;
+}
+
+describe('aiven_service_create wiring', () => {
+  it('injects the origin tag into the POST body', async () => {
+    const { client, request, get } = createMockClient();
+    // resolveFreePlanCloud only fires for free-* plans, but the helper still
+    // calls client.get if it does — return an empty list so it no-ops cleanly.
+    get.mockResolvedValue({
+      free_plan_cloud_providers: [],
+      free_plan_cloud_preferences: [],
+    });
+
+    const create = findTool(loadApiTools(client), 'aiven_service_create');
+
+    await create.handler({
+      project: 'my-proj',
+      service_name: 'my-svc',
+      service_type: 'pg',
+      plan: 'startup-4',
+      cloud: 'aws-eu-west-1',
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0];
+    if (!call) throw new Error('expected request call');
+    const body = call[2] as Record<string, unknown>;
+    expect(body).toMatchObject({
+      service_name: 'my-svc',
+      service_type: 'pg',
+      tags: { [AI_ORIGIN_TAG_KEY]: AI_ORIGIN_TAG_VALUE },
+    });
+  });
+
+  it('preserves user-supplied tags and never overrides origin', async () => {
+    const { client, request } = createMockClient();
+
+    const create = findTool(loadApiTools(client), 'aiven_service_create');
+
+    await create.handler({
+      project: 'my-proj',
+      service_name: 'my-svc',
+      service_type: 'pg',
+      plan: 'startup-4',
+      cloud: 'aws-eu-west-1',
+      tags: { team: 'platform', [AI_ORIGIN_TAG_KEY]: 'custom' },
+    });
+
+    const call = request.mock.calls[0];
+    if (!call) throw new Error('expected request call');
+    const body = call[2] as Record<string, unknown>;
+    expect(body).toMatchObject({
+      tags: { team: 'platform', [AI_ORIGIN_TAG_KEY]: 'custom' },
+    });
+  });
+});
+
+describe('aiven_application_deploy wiring', () => {
+  it('injects the origin tag into the deploy POST body', async () => {
+    const { client, post } = createMockClient();
+
+    const deploy = findTool(createApplicationTools(client), ApplicationToolName.Deploy);
+
+    await deploy.handler({
+      project: 'my-proj',
+      service_name: 'my-app',
+      repository_url: 'https://github.com/me/repo',
+      branch: 'main',
+      build_path: '.',
+      port: 3000,
+      port_name: 'default',
+      plan: 'startup-50-1024',
+      cloud: 'aws-eu-west-1',
+      app_env_key: 'API_URL',
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const call = post.mock.calls[0];
+    if (!call) throw new Error('expected post call');
+    const [path, body] = call as [string, Record<string, unknown>];
+    expect(path).toBe('/project/my-proj/service');
+    expect(body).toMatchObject({
+      service_name: 'my-app',
+      service_type: 'application',
+      tags: { [AI_ORIGIN_TAG_KEY]: AI_ORIGIN_TAG_VALUE },
+    });
+  });
+});


### PR DESCRIPTION
## What

Every Aiven service created through the MCP (`aiven_service_create` or `aiven_application_deploy`) is now stamped with an `origin: mcp-aiven` resource tag, so AI-created resources can be identified and filtered across the Console and API.

## How

A thin helper `withOriginTag(body)` in `src/shared/ai-tags.ts` merges the tag into the outgoing POST body. 
It never overwrites a caller-supplied `origin` value and preserves all other tags.

<img width="295" height="138" alt="Screenshot 2026-04-29 at 11 23 03" src="https://github.com/user-attachments/assets/d2916c00-0346-4f08-afc4-45818ae76503" />
<img width="573" height="147" alt="Screenshot 2026-04-29 at 11 21 27" src="https://github.com/user-attachments/assets/3e7829ec-d443-4cdc-a8a1-637a9ab1c855" />


