### PR TITLE
feat: add remote read_only support by query param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build output
 dist/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Add to `.vscode/mcp.json` in your workspace:
 }
 ```
 
+#### Read-Only Mode (Remote)
+
+Enable read-only mode by adding `?read_only=true` to the URL. All write operations will be excluded from the MCP:
+
+```json
+{
+  "mcpServers": {
+    "aiven-mcp": {
+      "url": "https://mcp.aiven.live/mcp?read_only=true"
+    }
+  }
+}
+```
+
 ### Option 2: stdio (local)
 
 Run the server locally as a child process of your MCP client. Requires Node.js 18+.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ import { createKafkaCustomTools } from './tools/kafka/index.js';
 import { createPgCustomTools } from './tools/pg/index.js';
 import { createApplicationTools } from './tools/applications/index.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
-import type { ToolDefinition } from './types.js';
+import type { ToolDefinition, McpRequestOptions } from './types.js';
 import { VERSION, API_ORIGIN, loadHttpMcpRateLimit, httpTrustProxyEnabled } from './config.js';
-import { READ_ONLY_INSTRUCTIONS } from './prompts.js';
+import { readOnlyInstructions } from './prompts.js';
 
 /** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
 function mcpClientFromRequestInfo(requestInfo: unknown): string | undefined {
@@ -24,22 +24,16 @@ function mcpClientFromRequestInfo(requestInfo: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined;
 }
 
-function loadTools(client: AivenClient, readOnly: boolean): ToolDefinition[] {
-  let tools: ToolDefinition[] = [
+function loadAllTools(client: AivenClient): ToolDefinition[] {
+  return [
     ...loadApiTools(client),
     ...createKafkaCustomTools(client),
     ...createPgCustomTools(client),
     ...createApplicationTools(client),
   ];
-
-  if (readOnly) {
-    tools = tools.filter((t) => t.definition.annotations.readOnlyHint);
-  }
-
-  return tools;
 }
 
-function registerTools(server: McpServer, tools: ToolDefinition[]): void {
+function registerTools(server: McpServer, tools: readonly ToolDefinition[]): void {
   for (const tool of tools) {
     server.registerTool(
       tool.name,
@@ -65,13 +59,18 @@ async function main(): Promise<void> {
   const transport = process.env['MCP_TRANSPORT'] === 'http' ? 'http' : 'stdio';
   const config = loadConfig(transport);
   const client = new AivenClient(config);
-  const tools = loadTools(client, config.readOnly);
 
-  const serverOptions = config.readOnly
-    ? ([{ instructions: READ_ONLY_INSTRUCTIONS }] as const)
-    : ([] as const);
+  const allTools: readonly ToolDefinition[] = loadAllTools(client);
 
-  function createMcpServer(): McpServer {
+  function createMcpServer(options: McpRequestOptions): McpServer {
+    const tools = options.readOnly
+      ? allTools.filter((t) => t.definition.annotations.readOnlyHint)
+      : allTools;
+
+    const serverOptions = options.readOnly
+      ? ([{ instructions: readOnlyInstructions(transport) }] as const)
+      : ([] as const);
+
     const server = new McpServer({ name: 'mcp-aiven', version: VERSION }, ...serverOptions);
     registerTools(server, tools);
     return server;
@@ -84,9 +83,10 @@ async function main(): Promise<void> {
       scopes: ['projects', 'services', 'accounts:read'],
       rateLimit: loadHttpMcpRateLimit(),
       trustProxy: httpTrustProxyEnabled(),
+      readOnly: config.readOnly,
     });
   } else {
-    const server = createMcpServer();
+    const server = createMcpServer({ readOnly: config.readOnly });
     await server.connect(createStdioTransport());
     console.error('mcp-aiven: Server connected and ready');
   }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,8 +1,16 @@
-export const READ_ONLY_INSTRUCTIONS =
-  'This server is running in READ-ONLY mode. Only read/query tools are available. ' +
-  'You CANNOT create, update, or delete any resources. ' +
-  'If the user asks to make changes, inform them that the server is in read-only mode ' +
-  'and they need to set AIVEN_READ_ONLY=false to enable write operations.';
+export function readOnlyInstructions(transport: 'stdio' | 'http'): string {
+  const howToDisable =
+    transport === 'http'
+      ? 'they need to reconnect without the `read_only=true` query parameter to enable write operations.'
+      : 'they need to set AIVEN_READ_ONLY=false to enable write operations.';
+
+  return (
+    'This server is running in READ-ONLY mode. Only read/query tools are available. ' +
+    'You CANNOT create, update, or delete any resources. ' +
+    'If the user asks to make changes, inform them that the server is in read-only mode and ' +
+    howToDisable
+  );
+}
 
 export const TOOL_LIST_PICKER_SUFFIX =
   '**Lists & picks:** When turning this tool’s output into user choices, curate **2–5** options at a time unless they explicitly ask for the full catalog. ' +

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -3,22 +3,23 @@ import express from 'express';
 import rateLimit, { ipKeyGenerator, type Options } from 'express-rate-limit';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Request, Response, NextFunction } from 'express';
 import { HOST } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
+import type { McpServerFactory, McpRequestOptions } from './types.js';
 
 export function createStdioTransport(): StdioServerTransport {
   return new StdioServerTransport();
 }
 
-interface HttpServerConfig {
+export interface HttpServerConfig {
   port: number;
   apiOrigin: string;
   scopes: string[];
   rateLimit: HttpMcpRateLimitConfig;
   trustProxy: boolean;
+  readOnly: boolean;
 }
 
 const RATE_LIMIT_PROPERTY = 'rateLimit' as const;
@@ -83,8 +84,34 @@ function mcpRequestKey(req: Request): string {
   return ipKeyGenerator(req.ip ?? '0.0.0.0');
 }
 
+const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only']);
+
+export function parseMcpQueryParams(
+  query: Record<string, unknown>,
+  serverReadOnly: boolean
+): { options: McpRequestOptions } | { error: string } {
+  const unknownParams = Object.keys(query).filter((k) => !ALLOWED_MCP_QUERY_PARAMS.has(k));
+  if (unknownParams.length > 0) {
+    return { error: `Unknown query parameter(s): ${unknownParams.join(', ')}` };
+  }
+
+  const rawReadOnly = query['read_only'];
+
+  if (Array.isArray(rawReadOnly)) {
+    return { error: 'Duplicate query parameter: read_only' };
+  }
+
+  if (rawReadOnly !== undefined && rawReadOnly !== 'true' && rawReadOnly !== 'false') {
+    return { error: `Invalid value for read_only: must be "true" or "false"` };
+  }
+
+  const readOnly = serverReadOnly || rawReadOnly === 'true';
+
+  return { options: { readOnly } };
+}
+
 export function startHttpServer(
-  createServer: () => McpServer,
+  createServer: McpServerFactory,
   config: HttpServerConfig
 ): void {
   const app = express();
@@ -120,9 +147,15 @@ export function startHttpServer(
 
   app.post('/mcp', mcpPostRateLimit, authMiddleware, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
+      const parsed = parseMcpQueryParams(req.query as Record<string, unknown>, config.readOnly);
+      if ('error' in parsed) {
+        res.status(400).json({ error: parsed.error });
+        return;
+      }
+
       const token = (req as Request & { token: string }).token;
       const transport = new StreamableHTTPServerTransport({ enableJsonResponse: true });
-      const mcpServer = createServer();
+      const mcpServer = createServer(parsed.options);
       await mcpServer.connect(transport as unknown as Transport);
       (req as Request & { auth: { token: string; clientId: string; scopes: string[] } }).auth = {
         token,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,12 @@ export interface AivenConfig {
   readonly transport: 'stdio' | 'http';
 }
 
+export interface McpRequestOptions {
+  readonly readOnly: boolean;
+}
+
+export type McpServerFactory = (options: McpRequestOptions) => import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;
+
 export interface RequestOptions {
   query?: Record<string, string | number | boolean | undefined> | undefined;
   timeout?: number | undefined;

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { parseMcpQueryParams } from '../../src/transport.js';
+
+describe('parseMcpQueryParams', () => {
+  describe('valid inputs', () => {
+    it('returns readOnly=false when no query params', () => {
+      const result = parseMcpQueryParams({}, false);
+      expect(result).toEqual({ options: { readOnly: false } });
+    });
+
+    it('returns readOnly=true when read_only=true', () => {
+      const result = parseMcpQueryParams({ read_only: 'true' }, false);
+      expect(result).toEqual({ options: { readOnly: true } });
+    });
+
+    it('returns readOnly=false when read_only=false', () => {
+      const result = parseMcpQueryParams({ read_only: 'false' }, false);
+      expect(result).toEqual({ options: { readOnly: false } });
+    });
+  });
+
+  describe('server-level enforcement (env var)', () => {
+    it('cannot override server readOnly=true with read_only=false', () => {
+      const result = parseMcpQueryParams({ read_only: 'false' }, true);
+      expect(result).toEqual({ options: { readOnly: true } });
+    });
+
+    it('server readOnly=true with no query param stays true', () => {
+      const result = parseMcpQueryParams({}, true);
+      expect(result).toEqual({ options: { readOnly: true } });
+    });
+
+    it('server readOnly=true with read_only=true stays true', () => {
+      const result = parseMcpQueryParams({ read_only: 'true' }, true);
+      expect(result).toEqual({ options: { readOnly: true } });
+    });
+  });
+
+  describe('rejects invalid inputs', () => {
+    it('rejects unknown query parameters', () => {
+      const result = parseMcpQueryParams({ read_only: 'true', foo: 'bar' }, false);
+      expect(result).toEqual({ error: 'Unknown query parameter(s): foo' });
+    });
+
+    it('rejects multiple unknown query parameters', () => {
+      const result = parseMcpQueryParams({ foo: 'bar', baz: '1' }, false);
+      expect(result).toEqual({ error: 'Unknown query parameter(s): foo, baz' });
+    });
+
+    it('rejects array values (duplicate param injection)', () => {
+      const result = parseMcpQueryParams({ read_only: ['true', 'false'] }, false);
+      expect(result).toEqual({ error: 'Duplicate query parameter: read_only' });
+    });
+
+    it('rejects invalid read_only value "1"', () => {
+      const result = parseMcpQueryParams({ read_only: '1' }, false);
+      expect(result).toEqual({ error: 'Invalid value for read_only: must be "true" or "false"' });
+    });
+
+    it('rejects invalid read_only value "yes"', () => {
+      const result = parseMcpQueryParams({ read_only: 'yes' }, false);
+      expect(result).toEqual({ error: 'Invalid value for read_only: must be "true" or "false"' });
+    });
+
+    it('rejects invalid read_only value "TRUE" (case sensitive)', () => {
+      const result = parseMcpQueryParams({ read_only: 'TRUE' }, false);
+      expect(result).toEqual({ error: 'Invalid value for read_only: must be "true" or "false"' });
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it('produces independent results for different inputs (no shared state)', () => {
+      const orgA = parseMcpQueryParams({ read_only: 'true' }, false);
+      const orgB = parseMcpQueryParams({}, false);
+
+      expect(orgA).toEqual({ options: { readOnly: true } });
+      expect(orgB).toEqual({ options: { readOnly: false } });
+    });
+  });
+});


### PR DESCRIPTION
Enable per-request read-only mode via URL query parameter: https://mcp.aiven.live/mcp?read_only=true

[EVERSQL-1817]