### PR TITLE
feat: make MCP host URL configurable via MCP_HOST env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Config file locations:
 |---|---|---|---|
 | `AIVEN_TOKEN` | stdio only | -- | Aiven API token ([create one here](https://console.aiven.io/profile/tokens)) |
 | `AIVEN_READ_ONLY` | No | `false` | Set to `true` to expose only read-only tools |
+| `MCP_HOST` | No | `https://mcp.aiven.live` | Public base URL of this server, advertised in OAuth protected resource metadata. Override when deploying behind a custom domain. |
 
 In remote (HTTP) mode, `AIVEN_TOKEN` is not needed. Your MCP client sends your token as a Bearer token with each request.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ const pkg = require('../package.json') as { version: string };
 export const VERSION = pkg.version;
 export const API_ORIGIN = process.env['AIVEN_API_ORIGIN'] ?? 'https://api.aiven.io';
 export const API_BASE_URL = `${API_ORIGIN}/v1`;
-export const HOST = 'https://mcp.aiven.live'
+export const HOST = process.env['MCP_HOST'] ?? 'https://mcp.aiven.live'
 
 /** HTTP POST /mcp rate limit (per bearer token hash, else per client IP). */
 export interface HttpMcpRateLimitConfig {


### PR DESCRIPTION
## Summary

The `HOST` constant (used in the `/.well-known/oauth-protected-resource` endpoint) was hardcoded to `https://mcp.aiven.live`. This causes Cursor to reject connections when the server is accessed through a different domain, since it validates that the advertised resource URL matches the URL it connected to.

This PR makes it configurable via `MCP_HOST` env var — default remains `https://mcp.aiven.live` so there is no change for existing deployments.

Two use cases:
1. Testing (immediate need) — deploy the same mcp-aiven image behind a different domain (e.g. mcp.tunemysql.com) and have the OAuth resource URL match, so clients like Cursor don't reject it.
2. Self-hosted MCP server (future) — if a customer wants to run their own instance of mcp-aiven behind their own domain (e.g. mcp.acme.com), they just set MCP_HOST env var to https://mcp.acme.com and everything works — the OAuth metadata advertises the right URL, clients connect without security errors.

## Changes

- `src/config.ts` — `HOST` now reads from `process.env['MCP_HOST'] ?? 'https://mcp.aiven.live'`
- `README.md` — documents the new env var


Made with [Cursor](https://cursor.com)