### PR TITLE
feat: add CI and release github actions workflows, bump version to 1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,115 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate API types
+        run: pnpm generate:api-types
+
+      - name: Generate schemas
+        run: pnpm generate
+
+      - name: Lint
+        run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate API types
+        run: pnpm generate:api-types
+
+      - name: Generate schemas
+        run: pnpm generate
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate API types
+        run: pnpm generate:api-types
+
+      - name: Generate schemas
+        run: pnpm generate
+
+      - name: Run unit tests
+        run: pnpm test -- --run
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate API types
+        run: pnpm generate:api-types
+
+      - name: Generate schemas
+        run: pnpm generate
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -1,0 +1,75 @@
+name: Version Tag
+
+on:
+  pull_request:
+  workflow_run:
+    workflows: [Tests]
+    branches: [main]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  version-tag:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine version
+        id: version
+        run: |
+          DRY_RUN=${{ github.event_name == 'pull_request' }}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+          LATEST_VERSION=${LATEST_TAG#v}
+
+          if [ -z "$LATEST_VERSION" ] || [ "$PKG_VERSION" != "$LATEST_VERSION" ]; then
+            VERSION="$PKG_VERSION"
+            NEEDS_BUMP=false
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$PKG_VERSION"
+            VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+            NEEDS_BUMP=true
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "needs_bump=$NEEDS_BUMP" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+
+          echo "📦 Next version: v$VERSION"
+          echo "   Latest tag: ${LATEST_TAG:-none}"
+          echo "   package.json: $PKG_VERSION"
+          echo "   Auto-bump: $NEEDS_BUMP"
+          echo "   Dry run: $DRY_RUN"
+
+      - name: Bump package.json (patch auto-bump)
+        if: steps.version.outputs.needs_bump == 'true' && steps.version.outputs.dry_run == 'false'
+        run: |
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git push origin HEAD:main
+
+      - name: Create tag and GitHub Release
+        if: steps.version.outputs.dry_run == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-aiven",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "MCP server for Aiven cloud data platform - manage PostgreSQL, Kafka, and other services",
   "type": "module",
   "main": "dist/index.js",
@@ -74,5 +74,6 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.28.2"
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -10,7 +10,13 @@ export function redactReasoningField(reasoning: unknown): string | null {
     return null;
   }
   if (typeof reasoning !== 'string') {
-    const stringified = String(reasoning);
+    let stringified: string;
+    try {
+      stringified = JSON.stringify(reasoning);
+    } catch {
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      stringified = String(reasoning);
+    }
     const wrapped = { reasoning: stringified };
     const redacted = redactSensitiveData(wrapped) as { reasoning: string };
     return redacted.reasoning;

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -87,7 +87,9 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
       try {
         const args = params as Record<string, unknown>;
-        const { reasoning, ...argsWithoutReasoning } = args;
+        const argsWithoutReasoning = Object.fromEntries(
+          Object.entries(args).filter(([key]) => key !== 'reasoning')
+        );
 
         const opts: RequestOptions = {
           token: context?.token,

--- a/tests/runtime/observability.test.ts
+++ b/tests/runtime/observability.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { redactReasoningField } from '../../src/observability.js';
+import { REDACTED_PLACEHOLDER } from '../../src/security.js';
+
+describe('redactReasoningField', () => {
+  it('returns null for undefined', () => {
+    expect(redactReasoningField(undefined)).toBeNull();
+  });
+
+  it('returns null for null', () => {
+    expect(redactReasoningField(null)).toBeNull();
+  });
+
+  it('returns empty string as-is', () => {
+    expect(redactReasoningField('')).toBe('');
+  });
+
+  it('returns plain string as-is', () => {
+    expect(redactReasoningField('the user wants to list services')).toBe(
+      'the user wants to list services'
+    );
+  });
+
+  it('redacts string that is a bare sensitive URI', () => {
+    expect(redactReasoningField('postgres://admin:secret@host:5432/db')).toBe(
+      REDACTED_PLACEHOLDER
+    );
+  });
+
+  it('does not redact string with embedded URI (redaction is value-level, not substring)', () => {
+    const input = 'connect to postgres://admin:secret@host:5432/db';
+    const result = redactReasoningField(input);
+    expect(result).toBe(input);
+  });
+
+  it('serializes object reasoning via JSON.stringify', () => {
+    const result = redactReasoningField({ key: 'value', count: 42 });
+    expect(result).toBe('{"key":"value","count":42}');
+  });
+
+  it('serializes array reasoning via JSON.stringify', () => {
+    expect(redactReasoningField([1, 2, 3])).toBe('[1,2,3]');
+  });
+
+  it('serializes number reasoning via JSON.stringify', () => {
+    expect(redactReasoningField(42)).toBe('42');
+  });
+
+  it('serializes boolean reasoning via JSON.stringify', () => {
+    expect(redactReasoningField(true)).toBe('true');
+  });
+
+  it('falls back to String() for circular references', () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    const result = redactReasoningField(circular);
+    expect(result).toBe('[object Object]');
+  });
+});

--- a/tests/runtime/tools.test.ts
+++ b/tests/runtime/tools.test.ts
@@ -51,9 +51,10 @@ describe('toolSuccess', () => {
       expect(result.isError).toBeUndefined();
       const out = firstTextContent(result.content);
       expect(out).toBeDefined();
-      expect(out!.length).toBeLessThanOrEqual(600);
-      expect(out!.toLowerCase()).toMatch(/trim(med)?|mcp-aiven/);
-      expect(out!.startsWith('aaa')).toBe(true);
+      const text = out as string;
+      expect(text.length).toBeLessThanOrEqual(600);
+      expect(text.toLowerCase()).toMatch(/trim(med)?|mcp-aiven/);
+      expect(text.startsWith('aaa')).toBe(true);
     } finally {
       if (prev === undefined) delete process.env['MCP_MAX_TOOL_RESULT_CHARS'];
       else process.env['MCP_MAX_TOOL_RESULT_CHARS'] = prev;


### PR DESCRIPTION
## Summary

- `test.yml`: Runs lint, typecheck, test, and build on every PR. Uses concurrency groups to cancel stale runs.
- `version-tag.yml`: On merge to main, compares package.json version with the latest git tag. If unchanged, auto-bumps patch (e.g., 1.0.0 → 1.0.1). If manually bumped (major/minor), uses it as-is. Creates an annotated git tag, a GitHub Release with auto-generated notes.
- `Version bump`: 0.1.5 → 1.0.0 to mark the first stable release.
- `Lint fixes`: non-null assertions in tests/runtime/tools.test.ts, no-base-to-string in src/observability.ts, no-unused-vars in src/tools/api-tool.ts.

Phase 2 of CD (publishing to npm, deployment) will be done in a separate PR


Made with [Cursor](https://cursor.com)