### PR TITLE
fix:  service list custom tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createKafkaCustomTools } from './tools/kafka/index.js';
 import { createPgCustomTools } from './tools/pg/index.js';
 import { createApplicationTools } from './tools/applications/index.js';
 import { createDocsTools } from './tools/docs/index.js';
+import { createServiceSearchTool } from './tools/service-search.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
 import type { ToolDefinition, McpRequestOptions } from './types.js';
 import { VERSION, API_ORIGIN, loadHttpMcpRateLimit, httpTrustProxyEnabled } from './config.js';
@@ -32,6 +33,7 @@ function loadAllTools(client: AivenClient): ToolDefinition[] {
     ...createPgCustomTools(client),
     ...createApplicationTools(client),
     ...createDocsTools(),
+    ...createServiceSearchTool(client),
   ];
 }
 

--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -38,21 +38,6 @@ tools:
       - provider: Cloud vendor (e.g. `aws-eu-central-2`, `google-europe-north2`)
       - geo_region: Broad geography (e.g. `europe`, `north america`)
 
-  - name: aiven_service_list
-    method: GET
-    path: /project/{project}/service
-    category: core
-    append_list_picker_hint: true
-    exclude_params: [include_secrets]
-    response_filter:
-      key: services
-      fields: [service_name, service_type]
-    description: |
-      List services in a project. `project` must be a valid Aiven project name from `aiven_project_list`.
-      This tool returns a list of services with the following fields:
-      - service_name: The name of the service
-      - service_type: The type of the service
-
   - name: aiven_service_type_plans
     method: GET
     path: /project/{project}/service-types/{service_type}/plans

--- a/src/tools/service-search.ts
+++ b/src/tools/service-search.ts
@@ -1,0 +1,136 @@
+import { z } from 'zod';
+import type { AivenClient } from '../client.js';
+import type { ToolDefinition, ToolResult, HandlerContext } from '../types.js';
+import { ServiceCategory, READ_ONLY_ANNOTATIONS, toolSuccess, toolError } from '../types.js';
+import { errorMessage } from '../errors.js';
+import { wrapUntrustedResponse } from '../untrusted.js';
+import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
+
+const CONCURRENCY = 10;
+const MAX_RESULTS = 15;
+
+const inputSchema = z.object({
+  project: z
+    .string()
+    .optional()
+    .describe('Scope to a single project. If omitted, searches across all projects.'),
+  service_type: z
+    .string()
+    .optional()
+    .describe('Filter by service type (e.g. "pg", "kafka", "opensearch", "mysql", "redis")'),
+  state: z
+    .string()
+    .optional()
+    .describe('Filter by service state (e.g. "RUNNING", "POWERED_OFF", "REBUILDING")'),
+  limit: z
+    .number()
+    .optional()
+    .describe(`Max results to return. Defaults to ${MAX_RESULTS}. Set higher only if the user asks for the full list.`),
+});
+
+interface ServiceEntry {
+  service_name: string;
+  service_type: string;
+  state: string;
+}
+
+interface ProjectEntry {
+  project_name: string;
+}
+
+const DESCRIPTION = `Search for Aiven services. Optionally scope to a single project or search across all projects.
+
+Returns a filtered list of services matching the criteria. All filters are optional — omit them to get all services.
+
+This tool returns a list of services with the following fields:
+- project: The project the service belongs to
+- service_name: The name of the service
+- service_type: The type of the service
+- state: The current state of the service (e.g. RUNNING, POWERED_OFF)
+
+Use \`aiven_service_get\` to get full details for a specific service.
+
+${TOOL_LIST_PICKER_SUFFIX}`;
+
+interface ServiceResult {
+  project: string;
+  service_name: string;
+  service_type: string;
+  state: string;
+}
+
+interface ProjectError {
+  project: string;
+  error: string;
+}
+
+export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
+  return [
+    {
+      name: 'aiven_service_list',
+      category: ServiceCategory.Core,
+      definition: {
+        title: 'Search Services Across Projects',
+        description: DESCRIPTION,
+        inputSchema,
+        annotations: READ_ONLY_ANNOTATIONS,
+      },
+      handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
+        try {
+          const { project, service_type, state, limit } = params as z.infer<typeof inputSchema>;
+          const opts = { token: context?.token, mcpClient: context?.mcpClient, toolName: 'aiven_service_list' };
+
+          let projectNames: string[];
+          if (project) {
+            projectNames = [project];
+          } else {
+            const projectsRes = await client.get<{ projects: ProjectEntry[] }>('/project', opts);
+            projectNames = projectsRes.projects.map((p) => p.project_name);
+          }
+
+          const maxResults = limit ?? MAX_RESULTS;
+          const services: ServiceResult[] = [];
+          const errors: ProjectError[] = [];
+          const typeFilter = service_type?.toLowerCase();
+          const stateFilter = state?.toLowerCase();
+
+          while (projectNames.length > 0 && services.length < maxResults) {
+            const batch = projectNames.splice(0, CONCURRENCY);
+            const batchResults = await Promise.all(batch.map(async (proj) => {
+              try {
+                const res = await client.get<{ services: ServiceEntry[] }>(`/project/${encodeURIComponent(proj)}/service`, opts);
+                return { proj, services: res.services };
+              } catch (err) {
+                return { proj, error: errorMessage(err) };
+              }
+            }));
+
+            for (const entry of batchResults) {
+              if ('error' in entry) {
+                errors.push({ project: entry.proj, error: entry.error });
+                continue;
+              }
+              for (const s of entry.services) {
+                if (typeFilter && s.service_type.toLowerCase() !== typeFilter) continue;
+                if (stateFilter && s.state.toLowerCase() !== stateFilter) continue;
+                services.push({ project: entry.proj, service_name: s.service_name, service_type: s.service_type, state: s.state });
+              }
+            }
+          }
+
+          const hasMore = services.length > maxResults || projectNames.length > 0;
+          const result = services.slice(0, maxResults);
+
+          return toolSuccess(wrapUntrustedResponse({
+            showing: result.length,
+            ...(hasMore && { hint: 'More services may exist. Use a higher limit or narrow with filters (project, service_type, state) to see more.' }),
+            services: result,
+            ...(errors.length > 0 && { errors }),
+          }));
+        } catch (err) {
+          return toolError(errorMessage(err));
+        }
+      },
+    },
+  ];
+}

--- a/tests/runtime/service-search.test.ts
+++ b/tests/runtime/service-search.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createServiceSearchTool } from '../../src/tools/service-search.js';
+import type { AivenClient } from '../../src/client.js';
+import type { ToolResult } from '../../src/types.js';
+
+interface ParsedResponse {
+  showing: number;
+  hint?: string;
+  services: Array<{ project: string; service_name: string; service_type: string; state: string }>;
+  errors?: Array<{ project: string; error: string }>;
+}
+
+function parseResponse(result: ToolResult): ParsedResponse {
+  const content = result.content as Array<{ type: string; text: string }>;
+  const text = content[0].text;
+  const wrapped = text.match(/<untrusted-aiven-response-[^>]+>\n([\s\S]*?)\n<\/untrusted-aiven-response/);
+  const json = wrapped ? wrapped[1] : text;
+  return JSON.parse(json) as ParsedResponse;
+}
+
+function makeServices(project: string, count: number, type = 'pg', state = 'RUNNING'): Array<{ service_name: string; service_type: string; state: string }> {
+  return Array.from({ length: count }, (_, idx) => ({
+    service_name: `${project}-svc-${idx}`,
+    service_type: type,
+    state,
+  }));
+}
+
+function createMockClient(projects: string[], servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>>): AivenClient {
+  const get = vi.fn().mockImplementation((path: string) => {
+    if (path === '/project') {
+      return Promise.resolve({ projects: projects.map((p) => ({ project_name: p })) });
+    }
+    const match = path.match(/\/project\/([^/]+)\/service/);
+    if (match) {
+      const proj = decodeURIComponent(match[1]);
+      const services = servicesByProject[proj] ?? [];
+      return Promise.resolve({ services });
+    }
+    return Promise.reject(new Error(`unexpected path: ${path}`));
+  });
+  return { get, post: get, put: get, delete: get, patch: get, request: get } as unknown as AivenClient;
+}
+
+describe('service-search', () => {
+  it('returns services from a single project', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': makeServices('proj-a', 3),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(3);
+    expect(parsed.services).toHaveLength(3);
+    expect(parsed.services[0]).toMatchObject({ project: 'proj-a', service_name: 'proj-a-svc-0' });
+    expect(parsed.hint).toBeUndefined();
+    expect(parsed.errors).toBeUndefined();
+  });
+
+  it('searches across all projects when no project specified', async () => {
+    const client = createMockClient(['proj-a', 'proj-b'], {
+      'proj-a': makeServices('proj-a', 2),
+      'proj-b': makeServices('proj-b', 1),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({});
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(3);
+    expect(parsed.services).toHaveLength(3);
+  });
+
+  it('filters by service_type case-insensitively', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': [
+        { service_name: 'pg-1', service_type: 'pg', state: 'RUNNING' },
+        { service_name: 'kafka-1', service_type: 'kafka', state: 'RUNNING' },
+      ],
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', service_type: 'PG' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(1);
+    expect(parsed.services[0].service_name).toBe('pg-1');
+  });
+
+  it('filters by state case-insensitively', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': [
+        { service_name: 'svc-1', service_type: 'pg', state: 'RUNNING' },
+        { service_name: 'svc-2', service_type: 'pg', state: 'POWERED_OFF' },
+      ],
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', state: 'powered_off' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(1);
+    expect(parsed.services[0].service_name).toBe('svc-2');
+  });
+
+  it('respects limit and indicates more results exist', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': makeServices('proj-a', 10),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', limit: 3 });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(3);
+    expect(parsed.services).toHaveLength(3);
+    expect(parsed.hint).toContain('More services may exist');
+  });
+
+  it('stops fetching projects early when limit is reached', async () => {
+    const projects = Array.from({ length: 20 }, (_, idx) => `proj-${idx}`);
+    const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
+    for (const p of projects) {
+      servicesByProject[p] = makeServices(p, 5);
+    }
+    const client = createMockClient(projects, servicesByProject);
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ limit: 3 });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(3);
+    expect(parsed.hint).toContain('More services may exist');
+    // Should not have fetched all 20 projects (concurrency=10, so at most 1 batch of /service calls)
+    const getCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
+    expect(getCalls.length).toBeLessThan(20);
+  });
+
+  it('reports errors for failed projects without swallowing them', async () => {
+    const get = vi.fn().mockImplementation((path: string) => {
+      if (path === '/project') {
+        return Promise.resolve({ projects: [{ project_name: 'good' }, { project_name: 'bad' }] });
+      }
+      if (path.includes('/good/')) {
+        return Promise.resolve({ services: [{ service_name: 'svc-1', service_type: 'pg', state: 'RUNNING' }] });
+      }
+      return Promise.reject(new Error('forbidden'));
+    });
+    const client = { get, post: get, put: get, delete: get, patch: get, request: get } as unknown as AivenClient;
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({});
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(1);
+    expect(parsed.services[0].service_name).toBe('svc-1');
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors?.[0]).toMatchObject({ project: 'bad', error: 'forbidden' });
+  });
+
+  it('returns default MAX_RESULTS when no limit specified', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': makeServices('proj-a', 20),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(15);
+    expect(parsed.hint).toContain('More services may exist');
+  });
+});


### PR DESCRIPTION
#   Replace aiven_service_list YAML tool with a custom implementation

  The previous YAML-generated aiven_service_list only worked on a single project, forcing the LLM to loop over ~170 projects one by one for cross-project queries.

  The new custom tool:

  - Accepts an optional project param, scoped to one project (1 API call) or searches all projects when omitted
  - Adds service_type and state filters (case-insensitive) to reduce noise
  - Truncates results to 15 by default to avoid context bloat, with a limit param to fetch more if the user asks
  - Stops fetching additional projects early once the limit is reached, reducing API calls
  - Reports per-project errors instead of silently swallowing them
  - Returns lean fields (project, service_name, service_type, state) — use aiven_service_get for full details