### PR TITLE
feat: publish to npm on version tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for npm OIDC trusted publishing
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          check-latest: true # Ensure >= 22.14.0 required for trusted publishing
+          registry-url: https://registry.npmjs.org
+          cache: false # Never cache in release builds
+
+      - name: Update npm (trusted publishing requires >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish to npm
+        # Uses npm Trusted Publishers (OIDC) - no token needed.
+        # Provenance is generated automatically for public repos.
+        # The `prepublishOnly` script in package.json runs generate, build, and tests before publishing.
+        run: npm publish


### PR DESCRIPTION
## Summary

- Adds `publish.yml` workflow triggered on every `v*` tag push (created automatically by `version-tag.yml` after merge to main)
- Publishes to npm using **OIDC trusted publishing** — no secrets or tokens stored anywhere
- Provenance attestations are generated automatically (public repo + trusted publishing)
- Adds `mcpName` to `package.json` for future MCP Registry integration

## Trigger chain

```
merge to main → test.yml → version-tag.yml creates v* tag → publish.yml
```

## Prerequisites

Roman has already configured trusted publishing on npmjs.com — no further setup needed.