### PR TITLE
fix: set git identity before creating annotated tag

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -25,6 +25,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Determine version
         id: version
         run: |
@@ -57,8 +62,6 @@ jobs:
         if: steps.version.outputs.needs_bump == 'true' && steps.version.outputs.dry_run == 'false'
         run: |
           npm version ${{ steps.version.outputs.version }} --no-git-tag-version
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
           git push origin HEAD:main


### PR DESCRIPTION
## Summary

The `version-tag.yml` workflow failed on first run because `git tag -a` requires a committer identity. The `git config user.name/email` was inside the conditional bump step, so it didn't run when no bump was needed (first release from package.json).

Moves git config to run unconditionally after checkout.

**Failed run**: https://github.com/Aiven-Open/mcp-aiven/actions/runs/25435125984

Made with [Cursor](https://cursor.com)