### PR TITLE
feat: add search/limit filtering to list tools

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -29,6 +29,7 @@ tools:
     response_filter:
       key: clouds
       fields: [cloud_name, cloud_description, provider, geo_region]
+      search_fields: [cloud_name, provider, geo_region]
     description: |
       List clouds available for a project (regions/providers Aiven supports for deployment). Requires a valid `project` from `aiven_project_list`.
 
@@ -46,6 +47,7 @@ tools:
     response_filter:
       key: service_plans
       fields: [service_plan]
+      search_fields: [service_plan]
     description: |
       List available plans for a service type. Requires `project` — use `aiven_project_list` first if unknown.
 
@@ -235,3 +237,6 @@ tools:
     path: /project/{project}/events
     category: core
     append_list_picker_hint: true
+    response_filter:
+      key: events
+      search_fields: [actor, event_type, event_desc, service_name]

--- a/src/manifests/integrations.yaml
+++ b/src/manifests/integrations.yaml
@@ -7,6 +7,10 @@ tools:
     category: integrations
     readOnly: true
     append_list_picker_hint: true
+    response_filter:
+      key: service_integrations
+      fields: [service_integration_id, integration_type, source_service, dest_service, enabled, active]
+      search_fields: [integration_type]
     description: |
       List all integrations for a specific service. Returns both integrations where this service is the source and where it is the destination.
 
@@ -55,6 +59,10 @@ tools:
     category: integrations
     readOnly: true
     append_list_picker_hint: true
+    response_filter:
+      key: integration_types
+      fields: [integration_type, source_service_types, dest_service_types]
+      search_fields: [integration_type]
     description: |
       List all available service integration types for a project. Returns the integration type name along with the valid source and destination service types for each.
 
@@ -66,6 +74,10 @@ tools:
     category: integrations
     readOnly: true
     append_list_picker_hint: true
+    response_filter:
+      key: endpoint_types
+      fields: [endpoint_type, title, service_types]
+      search_fields: [endpoint_type]
     description: |
       List all available integration endpoint types for a project. Integration endpoints represent external services (e.g. Datadog, external Elasticsearch, Prometheus remote write, rsyslog, AWS CloudWatch, Google Cloud Logging).
 

--- a/src/manifests/kafka.yaml
+++ b/src/manifests/kafka.yaml
@@ -15,6 +15,9 @@ tools:
     path: /project/{project}/service/{service_name}/topic
     category: kafka
     append_list_picker_hint: true
+    response_filter:
+      key: topics
+      search_fields: [topic_name, topic_description]
     description: |
       This tool returns `topics`: an array of topic objects with:
       - topic_name: Topic name
@@ -116,6 +119,9 @@ tools:
     path: /project/{project}/service/{service_name}/available-connectors
     category: kafka
     append_list_picker_hint: true
+    response_filter:
+      key: plugins
+      search_fields: [plugin_type]
     description: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_list
@@ -123,6 +129,9 @@ tools:
     path: /project/{project}/service/{service_name}/connectors
     category: kafka
     append_list_picker_hint: true
+    response_filter:
+      key: connectors
+      search_fields: [name]
     description: |
       List Kafka Connect connectors with their configuration and task assignments.
 
@@ -189,6 +198,9 @@ tools:
     path: /project/{project}/service/{service_name}/kafka/schema/subjects
     category: kafka
     append_list_picker_hint: true
+    response_filter:
+      key: subjects
+      search_fields: [_string]
 
   - name: aiven_kafka_schema_registry_subject_version_get
     method: GET

--- a/src/manifests/pg.yaml
+++ b/src/manifests/pg.yaml
@@ -17,12 +17,19 @@ tools:
     path: /project/{project}/service/{service_name}/pg/available-extensions
     category: pg
     append_list_picker_hint: true
+    response_filter:
+      key: extensions
+      search_fields: [name]
 
   - name: aiven_pg_service_query_statistics
     method: POST
     path: /project/{project}/service/{service_name}/pg/query/stats
     category: pg
     readOnly: true
+    response_filter:
+      key: queries
+      fields: [query, database_name, user_name, calls, rows, mean_time, total_time, max_time]
+      search_fields: [query, database_name, user_name]
 
     description: |
       This tool returns **`queries`**: an array of one row per normalized query with:

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -4,7 +4,7 @@ import { toolSuccess, toolErrorWithRequestId } from '../types.js';
 import { errorMessage } from '../errors.js';
 import { redactSensitiveData } from '../security.js';
 import { wrapUntrustedResponse } from '../untrusted.js';
-import { applyResponseFilter } from './response-filter.js';
+import { applyResponseFilter, extendSchemaWithSearch, stripSearchParams } from './response-filter.js';
 
 function extractPathParams(path: string): Set<string> {
   return new Set(
@@ -74,6 +74,11 @@ async function executeRequest(
 
 export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolDefinition {
   const pathParams = extractPathParams(config.path);
+  // Extend the schema with search/limit/offset params if the tool has search_fields configured.
+  const inputSchema = config.responseFilter?.search_fields?.length
+    ? extendSchemaWithSearch(config.inputSchema, config.responseFilter)
+    : config.inputSchema;
+  const hasSearch = inputSchema !== config.inputSchema;
 
   return {
     name: config.name,
@@ -81,14 +86,19 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     definition: {
       title: config.title,
       description: config.description,
-      inputSchema: config.inputSchema,
+      inputSchema,
       annotations: config.annotations,
     },
     handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
       try {
         const args = params as Record<string, unknown>;
+        const apiArgs = hasSearch ? stripSearchParams(args) : args;
+        const search = hasSearch ? args['search'] as string | undefined : undefined;
+        const limit = hasSearch ? args['limit'] as number | undefined : undefined;
+        const offset = hasSearch ? args['offset'] as number | undefined : undefined;
+
         const argsWithoutReasoning = Object.fromEntries(
-          Object.entries(args).filter(([key]) => key !== 'reasoning')
+          Object.entries(apiArgs).filter(([key]) => key !== 'reasoning')
         );
 
         const opts: RequestOptions = {
@@ -100,12 +110,13 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
         };
 
         const data = await executeRequest(client, config, argsWithoutReasoning, pathParams, opts);
+        const redacted = redactSensitiveData(data);
 
         const filtered = config.responseFilter
-          ? applyResponseFilter(data, config.responseFilter)
-          : data;
+          ? applyResponseFilter(redacted, config.responseFilter, search, limit, offset)
+          : redacted;
 
-        return toolSuccess(wrapUntrustedResponse(redactSensitiveData(filtered)));
+        return toolSuccess(wrapUntrustedResponse(filtered));
       } catch (err) {
         return toolErrorWithRequestId(errorMessage(err), context?.requestId);
       }

--- a/src/tools/response-filter.ts
+++ b/src/tools/response-filter.ts
@@ -1,4 +1,49 @@
+import { z } from 'zod';
 import type { ResponseFilterConfig } from '../types.js';
+
+const SEARCH_PARAMS = new Set(['search', 'limit', 'offset']);
+export const DEFAULT_LIST_LIMIT = 15;
+const AUTO_RETURN_ALL_THRESHOLD = 30;
+
+export function extendSchemaWithSearch(
+  baseSchema: z.ZodType,
+  config: ResponseFilterConfig
+): z.ZodType {
+  if (!(baseSchema instanceof z.ZodObject)) return baseSchema;
+  const extra: Record<string, z.ZodType> = {};
+
+  if (config.search_fields?.length) {
+    const fieldList = config.search_fields.join('`, `');
+    extra['search'] = z
+      .string()
+      .optional()
+      .describe(
+        `Case-insensitive substring filter. Matches against \`${fieldList}\`. ` +
+          'Only items containing this string are returned.'
+      );
+    extra['limit'] = z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(`Max items to return. Do NOT set this unless the user explicitly asked for a specific number of results.`);
+    extra['offset'] = z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(`Number of items to skip for pagination. Use the value from the \`next_offset\` field in a previous response to fetch the next page.`);
+  }
+
+  if (Object.keys(extra).length === 0) return baseSchema;
+  return baseSchema.extend(extra).passthrough();
+}
+
+export function stripSearchParams(args: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(args).filter(([key]) => !SEARCH_PARAMS.has(key))
+  );
+}
 
 function pickFields(
   item: Record<string, unknown>,
@@ -9,22 +54,75 @@ function pickFields(
 
 export function applyResponseFilter(
   data: Record<string, unknown>,
-  config: ResponseFilterConfig
+  config: ResponseFilterConfig,
+  search: string | undefined,
+  limit: number | undefined,
+  offset: number | undefined
 ): Record<string, unknown> {
   const value = data[config.key];
-  const allowlist = new Set(config.fields);
 
-  if (Array.isArray(value)) {
-    return {
-      [config.key]: value.map((item: Record<string, unknown>) => pickFields(item, allowlist)),
-    };
+  // Field filtering on a single object (e.g. aiven_service_create response)
+  if (config.fields && !Array.isArray(value) && typeof value === 'object' && value !== null) {
+    const allowlist = new Set(config.fields);
+    return { [config.key]: pickFields(value as Record<string, unknown>, allowlist) };
   }
 
-  if (typeof value === 'object' && value !== null) {
-    return {
-      [config.key]: pickFields(value as Record<string, unknown>, allowlist),
-    };
+  if (!Array.isArray(value)) return data;
+
+  let items = value;
+
+  // Field filtering: strip columns
+  if (config.fields) {
+    const allowlist = new Set(config.fields);
+    items = items.map((item: Record<string, unknown>) => pickFields(item, allowlist));
   }
 
-  return data;
+  // If no search capabilities configured, return field-filtered data as-is
+  if (!config.search_fields && config.default_limit === undefined) {
+    return { ...data, [config.key]: items };
+  }
+
+  const isStringArray = items.length > 0 && typeof items[0] === 'string';
+
+  // Search filtering: match rows
+  let filtered = items;
+  if (search && config.search_fields && config.search_fields.length) {
+    const needle = search.toLowerCase();
+    const searchFields = config.search_fields;
+    filtered = isStringArray
+      ? items.filter((item: string) => item.toLowerCase().includes(needle))
+      : items.filter((item: Record<string, unknown>) =>
+          searchFields.some((field) => {
+            const val = item[field];
+            return typeof val === 'string' && val.toLowerCase().includes(needle);
+          })
+        );
+  }
+
+  // total = after all filtering, before pagination
+  const total = filtered.length;
+  const cap = Math.min(limit ?? config.default_limit ?? (total <= AUTO_RETURN_ALL_THRESHOLD ? total : DEFAULT_LIST_LIMIT), 100);
+  const pageStart = offset ?? 0;
+  const sliced = filtered.slice(pageStart, pageStart + cap);
+  const hasMore = pageStart + sliced.length < total;
+
+  const result: Record<string, unknown> = {
+    showing: sliced.length,
+    total,
+    ...(offset !== undefined && offset > 0 && { offset }),
+    [config.key]: sliced,
+  };
+
+  if (hasMore) {
+    const nextOffset = pageStart + sliced.length;
+    result['next_offset'] = nextOffset;
+    const largeWarning = total > 100
+      ? ` WARNING: ${total} items exist — fetching all would flood the context. Do NOT offer to fetch all or increase the limit.`
+      : '';
+    result['hint'] = search
+      ? `Showing ${sliced.length} of ${total} matches. Offer the user to refine the search or see the next page (\`offset: ${nextOffset}\`). Do NOT fetch more pages automatically.${largeWarning}`
+      : `Showing items ${pageStart + 1}–${pageStart + sliced.length} of ${total}. Ask the user what they are looking for, or offer to show the next page (\`offset: ${nextOffset}\`). Do NOT auto-paginate or increase limit without being asked.${largeWarning}`;
+  }
+
+  return result;
 }

--- a/src/tools/service-search.ts
+++ b/src/tools/service-search.ts
@@ -6,8 +6,9 @@ import { errorMessage } from '../errors.js';
 import { wrapUntrustedResponse } from '../untrusted.js';
 import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
 
+import { DEFAULT_LIST_LIMIT } from './response-filter.js';
+
 const CONCURRENCY = 10;
-const MAX_RESULTS = 15;
 
 const inputSchema = z.object({
   project: z
@@ -22,10 +23,20 @@ const inputSchema = z.object({
     .string()
     .optional()
     .describe('Filter by service state (e.g. "RUNNING", "POWERED_OFF", "REBUILDING")'),
+  search: z
+    .string()
+    .optional()
+    .describe('Case-insensitive substring filter on service_name.'),
   limit: z
     .number()
     .optional()
-    .describe(`Max results to return. Defaults to ${MAX_RESULTS}. Set higher only if the user asks for the full list.`),
+    .describe(`Max results to return. Defaults to ${DEFAULT_LIST_LIMIT}. Do NOT set this unless the user explicitly asked for a specific number of results.`),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Number of items to skip for pagination. Use the value from `next_offset` in a previous response.'),
 });
 
 interface ServiceEntry {
@@ -77,7 +88,7 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {
-          const { project, service_type, state, limit } = params as z.infer<typeof inputSchema>;
+          const { project, service_type, state, search, limit, offset } = params as z.infer<typeof inputSchema>;
           const opts = { token: context?.token, mcpClient: context?.mcpClient, toolName: 'aiven_service_list' };
 
           let projectNames: string[];
@@ -88,14 +99,18 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
             projectNames = projectsRes.projects.map((p) => p.project_name);
           }
 
-          const maxResults = limit ?? MAX_RESULTS;
+          const cap = Math.min(limit ?? DEFAULT_LIST_LIMIT, 100);
+          const pageStart = offset ?? 0;
           const services: ServiceResult[] = [];
           const errors: ProjectError[] = [];
           const typeFilter = service_type?.toLowerCase();
           const stateFilter = state?.toLowerCase();
+          const searchNeedle = search?.toLowerCase();
 
-          while (projectNames.length > 0 && services.length < maxResults) {
-            const batch = projectNames.splice(0, CONCURRENCY);
+          const needed = pageStart + cap;
+          const projectQueue = [...projectNames];
+          while (projectQueue.length > 0 && services.length < needed) {
+            const batch = projectQueue.splice(0, CONCURRENCY);
             const batchResults = await Promise.all(batch.map(async (proj) => {
               try {
                 const res = await client.get<{ services: ServiceEntry[] }>(`/project/${encodeURIComponent(proj)}/service`, opts);
@@ -113,19 +128,23 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
               for (const s of entry.services) {
                 if (typeFilter && s.service_type.toLowerCase() !== typeFilter) continue;
                 if (stateFilter && s.state.toLowerCase() !== stateFilter) continue;
+                if (searchNeedle && !s.service_name.toLowerCase().includes(searchNeedle)) continue;
                 services.push({ project: entry.proj, service_name: s.service_name, service_type: s.service_type, state: s.state });
               }
             }
           }
 
-          const hasMore = services.length > maxResults || projectNames.length > 0;
-          const result = services.slice(0, maxResults);
+          const page = services.slice(pageStart, pageStart + cap);
+          const hasMore = pageStart + page.length < services.length || projectQueue.length > 0;
+          const nextOffset = hasMore ? pageStart + page.length : undefined;
 
           return toolSuccess(wrapUntrustedResponse({
-            showing: result.length,
-            ...(hasMore && { hint: 'More services may exist. Use a higher limit or narrow with filters (project, service_type, state) to see more.' }),
-            services: result,
+            showing: page.length,
+            ...(offset !== undefined && offset > 0 && { offset }),
+            ...(nextOffset !== undefined && { next_offset: nextOffset }),
+            services: page,
             ...(errors.length > 0 && { errors }),
+            ...(hasMore && { hint: 'More services exist. Ask the user what they are looking for, or narrow with filters (project, service_type, state, search). Do NOT increase the limit or auto-paginate.' }),
           }));
         } catch (err) {
           return toolError(errorMessage(err));

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,7 +146,9 @@ export interface JsonSchema {
 
 export interface ResponseFilterConfig {
   key: string;
-  fields: string[];
+  fields?: string[];
+  search_fields?: string[];
+  default_limit?: number;
 }
 
 export type ToolSpec = ApiToolConfig;

--- a/tests/runtime/api-tool.test.ts
+++ b/tests/runtime/api-tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 import { createApiTool } from '../../src/tools/api-tool.js';
+import { applyResponseFilter as applyResultFilter } from '../../src/tools/response-filter.js';
 import {
   ServiceCategory,
   READ_ONLY_ANNOTATIONS,
@@ -40,6 +41,17 @@ function createErrorClient(status: number, message: string): AivenClient {
     patch: mockFn,
     request: mockFn,
   } as unknown as AivenClient;
+}
+
+function parseUntrustedResponse(text: string): unknown {
+  const match = text.match(
+    /<untrusted-aiven-response-[^>]+>\n([\s\S]*?)\n<\/untrusted-aiven-response-/
+  );
+  return JSON.parse(match?.[1] ?? '');
+}
+
+function parseResult(result: { content?: Array<{ type: string; text?: string }> }): Record<string, unknown> {
+  return parseUntrustedResponse(firstTextContent(result.content) ?? '') as Record<string, unknown>;
 }
 
 const baseConfig: ApiToolConfig = {
@@ -200,7 +212,7 @@ describe('createApiTool', () => {
     expect(firstTextContent(result.content)).toContain('Aiven API Error');
   });
 
-  it('should apply response filter when provided', async () => {
+  it('should apply result filter field selection', async () => {
     const config: ApiToolConfig = {
       ...baseConfig,
       responseFilter: {
@@ -217,11 +229,7 @@ describe('createApiTool', () => {
     const tool = createApiTool(config, client);
 
     const result = await tool.handler({});
-    const text = firstTextContent(result.content) ?? '';
-    const match = text.match(
-      /<untrusted-aiven-response-[^>]+>\n([\s\S]*?)\n<\/untrusted-aiven-response-/
-    );
-    const parsed = JSON.parse(match?.[1] ?? '');
+    const parsed = parseResult(result);
 
     expect(parsed).toEqual({ items: [{ name: 'a' }, { name: 'b' }] });
   });
@@ -253,5 +261,263 @@ describe('createApiTool', () => {
     expect(firstTextContent(result.content)).toContain('[REDACTED]');
     expect(firstTextContent(result.content)).not.toContain('secret');
     expect(firstTextContent(result.content)).toContain('test');
+  });
+
+  it('should filter by search param (case-insensitive)', async () => {
+    const items = [
+      { topic_name: 'orders-created' },
+      { topic_name: 'orders-updated' },
+      { topic_name: 'users-created' },
+    ];
+    const client = createMockClient({ topics: items });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'topics', search_fields: ['topic_name'] },
+    };
+    const tool = createApiTool(config, client);
+
+    const result = await tool.handler({ search: 'Orders' });
+    const parsed = parseResult(result);
+
+    expect(parsed['showing']).toBe(2);
+    expect(parsed['total']).toBe(2);
+    expect((parsed['topics'] as Array<{ topic_name: string }>).map((t) => t.topic_name)).toEqual([
+      'orders-created',
+      'orders-updated',
+    ]);
+  });
+
+  it('should search across multiple fields (OR)', async () => {
+    const items = [
+      { cloud_name: 'aws-eu-west-1', provider: 'aws', geo_region: 'europe' },
+      { cloud_name: 'google-europe-west1', provider: 'google', geo_region: 'europe' },
+      { cloud_name: 'do-fra', provider: 'do', geo_region: 'europe' },
+    ];
+    const client = createMockClient({ clouds: items });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'clouds', search_fields: ['cloud_name', 'provider', 'geo_region'] },
+    };
+    const tool = createApiTool(config, client);
+
+    const result = await tool.handler({ search: 'google' });
+    const parsed = parseResult(result);
+
+    expect(parsed['showing']).toBe(1);
+    expect(parsed['total']).toBe(1);
+  });
+
+  it('should apply default_limit when set', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ topic_name: `topic-${i}` }));
+    const client = createMockClient({ topics: items });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'topics', search_fields: ['topic_name'], default_limit: 3 },
+    };
+    const tool = createApiTool(config, client);
+
+    const result = await tool.handler({});
+    const parsed = parseResult(result);
+
+    expect(parsed['showing']).toBe(3);
+    expect(parsed['total']).toBe(10);
+    expect((parsed['topics'] as unknown[]).length).toBe(3);
+    expect(parsed['hint']).toContain('offset');
+  });
+
+  it('should cap at default 15 when no explicit default_limit is set', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({ topic_name: `topic-${i}` }));
+    const client = createMockClient({ topics: items });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'topics', search_fields: ['topic_name'] },
+    };
+    const tool = createApiTool(config, client);
+
+    const result = await tool.handler({});
+    const parsed = parseResult(result);
+
+    expect(parsed['showing']).toBe(15);
+    expect(parsed['total']).toBe(100);
+    expect((parsed['topics'] as unknown[]).length).toBe(15);
+    expect(parsed['hint']).toContain('offset');
+  });
+
+  it('should respect explicit limit param', async () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({ topic_name: `topic-${i}` }));
+    const client = createMockClient({ topics: items });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'topics', search_fields: ['topic_name'] },
+    };
+    const tool = createApiTool(config, client);
+
+    const result = await tool.handler({ limit: 5 });
+    const parsed = parseResult(result);
+
+    expect(parsed['showing']).toBe(5);
+    expect(parsed['total']).toBe(20);
+    expect((parsed['topics'] as unknown[]).length).toBe(5);
+  });
+
+  it('should not send search/limit params to API', async () => {
+    const client = createMockClient({ topics: [{ topic_name: 'a' }] });
+    const config: ApiToolConfig = {
+      ...baseConfig,
+      responseFilter: { key: 'topics', search_fields: ['topic_name'] },
+    };
+    const tool = createApiTool(config, client);
+
+    await tool.handler({ search: 'a', limit: 5 });
+
+    const callArgs = (client.get as ReturnType<typeof vi.fn>).mock.calls[0] as
+      | [string, { query?: unknown }]
+      | undefined;
+    expect(callArgs?.[1]?.query).toBeUndefined();
+  });
+});
+
+describe('applyResultFilter', () => {
+  it('should return data unchanged when key is not in response', () => {
+    const data = { other: 'value' };
+    const result = applyResultFilter(data, { key: 'topics', search_fields: ['topic_name'] }, undefined, undefined, undefined);
+    expect(result).toEqual(data);
+  });
+
+  it('should filter fields on a single object (non-array)', () => {
+    const data = { service: { name: 'svc', secret: '123', plan: 'startup-4' } };
+    const result = applyResultFilter(data, { key: 'service', fields: ['name', 'plan'] }, undefined, undefined, undefined);
+    expect(result).toEqual({ service: { name: 'svc', plan: 'startup-4' } });
+  });
+
+  it('should filter fields on array items', () => {
+    const data = { items: [{ name: 'a', extra: 'x' }, { name: 'b', extra: 'y' }] };
+    const result = applyResultFilter(data, { key: 'items', fields: ['name'] }, undefined, undefined, undefined);
+    expect(result).toEqual({ items: [{ name: 'a' }, { name: 'b' }] });
+  });
+
+  it('should handle string arrays (schema registry subjects)', () => {
+    const data = { subjects: ['orders-value', 'users-value', 'payments-value', 'orders-key'] };
+    const config = { key: 'subjects', search_fields: ['_string'] };
+
+    const result = applyResultFilter(data, config, 'orders', undefined, undefined);
+
+    expect(result).toEqual({
+      showing: 2,
+      total: 2,
+      subjects: ['orders-value', 'orders-key'],
+    });
+  });
+
+  it('should search across multiple fields with OR logic', () => {
+    const data = {
+      clouds: [
+        { cloud_name: 'aws-eu-west-1', provider: 'aws', geo_region: 'europe' },
+        { cloud_name: 'google-us-east1', provider: 'google', geo_region: 'north america' },
+        { cloud_name: 'do-fra', provider: 'do', geo_region: 'europe' },
+      ],
+    };
+
+    const result = applyResultFilter(
+      data,
+      { key: 'clouds', search_fields: ['cloud_name', 'provider', 'geo_region'] },
+      'europe',
+      undefined,
+      undefined
+    );
+
+    expect(result['showing']).toBe(2);
+    expect(result['total']).toBe(2);
+  });
+
+  it('should apply limit and add hint when capping', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ name: `item-${i}` }));
+    const result = applyResultFilter(
+      { items },
+      { key: 'items', search_fields: ['name'], default_limit: 3 },
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(result['showing']).toBe(3);
+    expect(result['total']).toBe(10);
+    expect(result['hint']).toBeDefined();
+  });
+
+  it('should return all items without hint when total is within auto-return threshold (<=30)', () => {
+    const items = Array.from({ length: 25 }, (_, i) => ({ name: `item-${i}` }));
+    const result = applyResultFilter(
+      { items },
+      { key: 'items', search_fields: ['name'] },
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(result['showing']).toBe(25);
+    expect(result['total']).toBe(25);
+    expect(result['hint']).toBeUndefined();
+  });
+
+  it('should combine field filtering with search', () => {
+    const data = {
+      clouds: [
+        { cloud_name: 'aws-eu-west-1', provider: 'aws', extra: 'drop' },
+        { cloud_name: 'google-us-east1', provider: 'google', extra: 'drop' },
+      ],
+    };
+
+    const result = applyResultFilter(
+      data,
+      { key: 'clouds', fields: ['cloud_name', 'provider'], search_fields: ['cloud_name'] },
+      'aws',
+      undefined,
+      undefined
+    );
+
+    const clouds = result['clouds'] as Array<Record<string, unknown>>;
+    expect(clouds).toHaveLength(1);
+    expect(clouds[0]).toEqual({ cloud_name: 'aws-eu-west-1', provider: 'aws' });
+    expect(clouds[0]?.['extra']).toBeUndefined();
+  });
+
+  it('should paginate with offset and return next_offset', () => {
+    const items = Array.from({ length: 25 }, (_, i) => ({ name: `item-${i}` }));
+    const page1 = applyResultFilter(
+      { items },
+      { key: 'items', search_fields: ['name'], default_limit: 10 },
+      undefined,
+      undefined,
+      undefined
+    );
+
+    expect(page1['showing']).toBe(10);
+    expect(page1['next_offset']).toBe(10);
+    expect(page1['hint']).toBeDefined();
+
+    const page2 = applyResultFilter(
+      { items },
+      { key: 'items', search_fields: ['name'], default_limit: 10 },
+      undefined,
+      undefined,
+      10
+    );
+
+    expect(page2['showing']).toBe(10);
+    expect(page2['next_offset']).toBe(20);
+    expect((page2['items'] as Array<Record<string, unknown>>)[0]).toEqual({ name: 'item-10' });
+
+    const page3 = applyResultFilter(
+      { items },
+      { key: 'items', search_fields: ['name'], default_limit: 10 },
+      undefined,
+      undefined,
+      20
+    );
+
+    expect(page3['showing']).toBe(5);
+    expect(page3['next_offset']).toBeUndefined();
+    expect(page3['hint']).toBeUndefined();
   });
 });

--- a/tests/runtime/service-search.test.ts
+++ b/tests/runtime/service-search.test.ts
@@ -5,6 +5,8 @@ import type { ToolResult } from '../../src/types.js';
 
 interface ParsedResponse {
   showing: number;
+  offset?: number;
+  next_offset?: number;
   hint?: string;
   services: Array<{ project: string; service_name: string; service_type: string; state: string }>;
   errors?: Array<{ project: string; error: string }>;
@@ -106,7 +108,8 @@ describe('service-search', () => {
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(3);
     expect(parsed.services).toHaveLength(3);
-    expect(parsed.hint).toContain('More services may exist');
+    expect(parsed.next_offset).toBe(3);
+    expect(parsed.hint).toContain('More services exist');
   });
 
   it('stops fetching projects early when limit is reached', async () => {
@@ -120,7 +123,7 @@ describe('service-search', () => {
     const result = await tool.handler({ limit: 3 });
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(3);
-    expect(parsed.hint).toContain('More services may exist');
+    expect(parsed.hint).toContain('More services exist');
     // Should not have fetched all 20 projects (concurrency=10, so at most 1 batch of /service calls)
     const getCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
     expect(getCalls.length).toBeLessThan(20);
@@ -146,7 +149,22 @@ describe('service-search', () => {
     expect(parsed.errors?.[0]).toMatchObject({ project: 'bad', error: 'forbidden' });
   });
 
-  it('returns default MAX_RESULTS when no limit specified', async () => {
+  it('filters by search (free-text on service_name)', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': [
+        { service_name: 'my-kafka', service_type: 'kafka', state: 'RUNNING' },
+        { service_name: 'my-pg', service_type: 'pg', state: 'RUNNING' },
+        { service_name: 'other-pg', service_type: 'pg', state: 'RUNNING' },
+      ],
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', search: 'my-' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(2);
+    expect(parsed.services.map((s) => s.service_name)).toEqual(['my-kafka', 'my-pg']);
+  });
+
+  it('returns default limit when no limit specified', async () => {
     const client = createMockClient(['proj-a'], {
       'proj-a': makeServices('proj-a', 20),
     });
@@ -154,6 +172,7 @@ describe('service-search', () => {
     const result = await tool.handler({ project: 'proj-a' });
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(15);
-    expect(parsed.hint).toContain('More services may exist');
+    expect(parsed.next_offset).toBe(15);
+    expect(parsed.hint).toContain('More services exist');
   });
 });


### PR DESCRIPTION
## Summary

Large list tools previously returned every item with no bound, polluting the LLM context window on busy clusters. This PR introduces client-side (MCP service) search, pagination, and smart limiting to all affected list tools.

- **`search` param** – added to all tools that declare `search_fields`; case-insensitive substring match across one or more configured fields
- **`limit` param** – hard cap of 100; defaults to **15** (or returns all if ≤ 30 results after filtering); only set when the user explicitly asks for a specific count
- **`offset` param** – offset-based pagination; response includes `next_offset` when more results exist, which can be passed directly into the next call
- **Response metadata** – filtered responses include `showing`, `total` (post-filter count, before pagination), `next_offset`, and a `hint` instructing the agent not to auto-paginate or increase the limit unprompted
- **`DEFAULT_LIST_LIMIT`** – single exported constant (15) shared by all tools including `aiven_service_list`'s custom handler

### Tools affected

| Tool | Search fields |
|------|--------------|
| `aiven_kafka_topic_list` | `topic_name`, `topic_description` |
| `aiven_kafka_connect_list` | `name` |
| `aiven_kafka_connect_available_connectors` | `plugin_type` |
| `aiven_kafka_schema_registry_subjects` | string value (schema name, e.g. `orders-value`) |
| `aiven_list_project_clouds` | `cloud_name`, `provider`, `geo_region` |
| `aiven_service_integration_list` | `integration_type` |
| `aiven_integration_types_list` | `integration_type` |
| `aiven_integration_endpoint_types_list` | `endpoint_type` |
| `aiven_pg_service_available_extensions` | `name` |
| `aiven_pg_service_query_statistics` | `query`, `database_name`, `user_name` |
| `aiven_project_get_event_logs` | `actor`, `event_type`, `event_desc`, `service_name` |
| `aiven_service_type_plans` | `service_plan` |
| `aiven_service_list` | `service_name` (extended existing handler — previously had `service_type`/`state` filters but no free-text search, pagination, or `total`) |

## Testing
- Unit tests
- Manual E2E testing for kafka topics and services list
- E2E testing+report summary by an agent for all of the tools

<img width="1045" height="996" alt="Screenshot 2026-05-10 at 17 18 17" src="https://github.com/user-attachments/assets/8af7f972-3a99-4736-a54a-f36a5ec4b3d8" />
<img width="1056" height="843" alt="Screenshot 2026-05-10 at 17 18 40" src="https://github.com/user-attachments/assets/08aaa75c-1914-4b6b-ab7b-9b293ffbf498" />
<img width="1009" height="548" alt="Screenshot 2026-05-10 at 17 19 07" src="https://github.com/user-attachments/assets/753fb263-fa3e-4c3e-9d9c-eb507291e6c7" />

