### PR TITLE
feat: add tools scoping to reduce context usage and improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ Enable read-only mode by adding `?read_only=true` to the URL. All write operatio
 }
 ```
 
+#### Scoped Tools (Remote)
+
+Reduce the tool surface exposed to your AI agent by adding `?services_scope=` to the URL. Useful when you only work with a subset of Aiven services and want to keep the agent's context focused. Combine values with commas. `core` (project/service discovery) is always included implicitly.
+
+Valid scopes: `all`, `core`, `pg`, `kafka`, `application`, `integrations`. Use `all` to explicitly load every tool (same as omitting the param). `all` cannot be combined with other scopes.
+
+```json
+{
+  "mcpServers": {
+    "aiven-mcp": {
+      "url": "https://mcp.aiven.live/mcp?services_scope=kafka"
+    }
+  }
+}
+```
+
+You can also combine with `read_only`:
+
+```
+https://mcp.aiven.live/mcp?services_scope=pg&read_only=true
+```
+
 ### Option 2: stdio (local)
 
 Run the server locally as a child process of your MCP client. Requires Node.js 18+.
@@ -124,6 +146,7 @@ MCP_HOST=http://localhost:3000 node dist/index.js
 |---|---|---|---|
 | `AIVEN_TOKEN` | stdio only | -- | Aiven API token ([create one here](https://console.aiven.io/profile/tokens)) |
 | `AIVEN_READ_ONLY` | No | `false` | Set to `true` to expose only read-only tools |
+| `AIVEN_SERVICES_SCOPE` | No | -- | Comma-separated scopes to expose (e.g. `kafka`, `pg,kafka`, or `all`). Valid: `all`, `core`, `pg`, `kafka`, `application`, `integrations`. `core` is always included. Omitting the var or setting `all` loads every tool. |
 | `MCP_HOST` | No | `https://mcp.aiven.live` | Override the OAuth protected resource host |
 | `MCP_TRANSPORT` | No | `stdio` | Set to `http` to start an HTTP server instead of stdio |
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import type { AivenConfig } from './types.js';
+import { ServiceCategory } from './types.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
@@ -34,6 +35,57 @@ export function httpTrustProxyEnabled(): boolean {
   return v === '1' || v === 'true';
 }
 
+/**
+ * User-selectable scope names. Maps to ServiceCategory; `core` is always implicitly included
+ * because every other category depends on `aiven_project_list` / `aiven_service_get` etc.
+ */
+const SCOPE_TO_CATEGORY: Record<string, ServiceCategory> = {
+  core: ServiceCategory.Core,
+  pg: ServiceCategory.Pg,
+  kafka: ServiceCategory.Kafka,
+  application: ServiceCategory.Application,
+  integrations: ServiceCategory.Integrations,
+};
+
+export const VALID_SCOPES = Object.freeze(['all', ...Object.keys(SCOPE_TO_CATEGORY)]);
+
+export function parseScopes(
+  raw: string | undefined
+): { categories: ReadonlySet<ServiceCategory> | undefined } | { error: string } {
+  if (raw === undefined) return { categories: undefined };
+
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  if (parts.length === 0) {
+    return { error: `Empty scope list. Valid scopes: ${VALID_SCOPES.join(', ')}` };
+  }
+
+  if (parts.includes('all')) {
+    if (parts.length > 1) {
+      return { error: `'all' cannot be combined with other scopes` };
+    }
+    return { categories: undefined };
+  }
+
+  const unknown = parts.filter((p) => !(p in SCOPE_TO_CATEGORY));
+  if (unknown.length > 0) {
+    return {
+      error: `Unknown scope(s): ${unknown.join(', ')}. Valid scopes: ${VALID_SCOPES.join(', ')}`,
+    };
+  }
+
+  const set = new Set<ServiceCategory>();
+  set.add(ServiceCategory.Core);
+  for (const p of parts) {
+    const cat = SCOPE_TO_CATEGORY[p];
+    if (cat) set.add(cat);
+  }
+  return { categories: set };
+}
+
 export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
   const token = process.env['AIVEN_TOKEN'];
 
@@ -46,5 +98,10 @@ export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
 
   const readOnly = process.env['AIVEN_READ_ONLY'] === 'true';
 
-  return { token, readOnly, transport };
+  const parsed = parseScopes(process.env['AIVEN_SERVICES_SCOPE']);
+  if ('error' in parsed) {
+    throw new Error(`AIVEN_SERVICES_SCOPE: ${parsed.error}`);
+  }
+
+  return { token, readOnly, transport, categories: parsed.categories };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,14 @@ async function main(): Promise<void> {
   const allTools: readonly ToolDefinition[] = loadAllTools(client);
 
   function createMcpServer(options: McpRequestOptions): McpServer {
-    const tools = options.readOnly
-      ? allTools.filter((t) => t.definition.annotations.readOnlyHint)
-      : allTools;
+    let tools: readonly ToolDefinition[] = allTools;
+    if (options.readOnly) {
+      tools = tools.filter((t) => t.definition.annotations.readOnlyHint);
+    }
+    if (options.categories) {
+      const allowed = options.categories;
+      tools = tools.filter((t) => allowed.has(t.category));
+    }
 
     const serverOptions = options.readOnly
       ? ([{ instructions: readOnlyInstructions(transport) }] as const)
@@ -98,7 +103,7 @@ async function main(): Promise<void> {
       readOnly: config.readOnly,
     });
   } else {
-    const server = createMcpServer({ readOnly: config.readOnly });
+    const server = createMcpServer({ readOnly: config.readOnly, categories: config.categories });
     await server.connect(createStdioTransport());
     console.error('mcp-aiven: Server connected and ready');
   }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -49,6 +49,11 @@ interface SchemaEntry {
 
 type SchemaMap = Record<string, SchemaEntry>;
 
+/**
+ * Maps YAML manifest `category:` values to `ServiceCategory`. `application` is intentionally
+ * absent — application tools are registered by `createApplicationTools` (custom handlers),
+ * not from a YAML manifest. If you add an `application.yaml` manifest, also add the entry here.
+ */
 const CATEGORY_MAP: Record<string, ServiceCategory> = {
   core: ServiceCategory.Core,
   pg: ServiceCategory.Pg,

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -5,7 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Request, Response, NextFunction } from 'express';
-import { HOST } from './config.js';
+import { HOST, parseScopes } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
 import type { McpServerFactory, McpRequestOptions } from './types.js';
 
@@ -84,7 +84,7 @@ function mcpRequestKey(req: Request): string {
   return ipKeyGenerator(req.ip ?? '0.0.0.0');
 }
 
-const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only']);
+const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only', 'services_scope']);
 
 export function parseMcpQueryParams(
   query: Record<string, unknown>,
@@ -107,7 +107,22 @@ export function parseMcpQueryParams(
 
   const readOnly = serverReadOnly || rawReadOnly === 'true';
 
-  return { options: { readOnly } };
+  const rawScope = query['services_scope'];
+
+  if (Array.isArray(rawScope)) {
+    return { error: 'Duplicate query parameter: services_scope' };
+  }
+
+  if (rawScope !== undefined && typeof rawScope !== 'string') {
+    return { error: 'Invalid value for services_scope: must be a comma-separated string' };
+  }
+
+  const parsed = parseScopes(rawScope);
+  if ('error' in parsed) {
+    return { error: `Invalid value for services_scope: ${parsed.error}` };
+  }
+
+  return { options: { readOnly, categories: parsed.categories } };
 }
 
 export function startHttpServer(

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,12 @@ export interface AivenConfig {
   readonly token: string | undefined;
   readonly readOnly: boolean;
   readonly transport: 'stdio' | 'http';
+  readonly categories: ReadonlySet<ServiceCategory> | undefined;
 }
 
 export interface McpRequestOptions {
   readonly readOnly: boolean;
+  readonly categories: ReadonlySet<ServiceCategory> | undefined;
 }
 
 export type McpServerFactory = (options: McpRequestOptions) => import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadConfig, loadHttpMcpRateLimit, httpTrustProxyEnabled } from '../../src/config.js';
+import {
+  loadConfig,
+  loadHttpMcpRateLimit,
+  httpTrustProxyEnabled,
+  parseScopes,
+} from '../../src/config.js';
+import { ServiceCategory } from '../../src/types.js';
 
 describe('loadConfig', () => {
   const originalEnv = process.env;
@@ -69,6 +75,85 @@ describe('loadConfig', () => {
     const config = loadConfig();
 
     expect(config.readOnly).toBe(false);
+  });
+
+  it('should leave categories undefined when AIVEN_SERVICES_SCOPE is unset', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    delete process.env['AIVEN_SERVICES_SCOPE'];
+
+    const config = loadConfig();
+
+    expect(config.categories).toBeUndefined();
+  });
+
+  it('should parse AIVEN_SERVICES_SCOPE into a category set with implicit core', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    process.env['AIVEN_SERVICES_SCOPE'] = 'kafka';
+
+    const config = loadConfig();
+
+    expect(config.categories).toEqual(new Set([ServiceCategory.Core, ServiceCategory.Kafka]));
+  });
+
+  it('should throw on unknown scope in AIVEN_SERVICES_SCOPE', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    process.env['AIVEN_SERVICES_SCOPE'] = 'postgres';
+
+    expect(() => loadConfig()).toThrow(/AIVEN_SERVICES_SCOPE.*Unknown scope/);
+  });
+});
+
+describe('parseScopes', () => {
+  it('returns undefined categories when input is undefined', () => {
+    expect(parseScopes(undefined)).toEqual({ categories: undefined });
+  });
+
+  it('parses single scope and includes core', () => {
+    expect(parseScopes('pg')).toEqual({
+      categories: new Set([ServiceCategory.Core, ServiceCategory.Pg]),
+    });
+  });
+
+  it('parses multiple scopes', () => {
+    expect(parseScopes('kafka,pg,application,integrations')).toEqual({
+      categories: new Set([
+        ServiceCategory.Core,
+        ServiceCategory.Kafka,
+        ServiceCategory.Pg,
+        ServiceCategory.Application,
+        ServiceCategory.Integrations,
+      ]),
+    });
+  });
+
+  it('trims whitespace around entries', () => {
+    expect(parseScopes(' kafka , pg ')).toEqual({
+      categories: new Set([ServiceCategory.Core, ServiceCategory.Kafka, ServiceCategory.Pg]),
+    });
+  });
+
+  it('rejects empty string', () => {
+    const r = parseScopes('');
+    expect(r).toMatchObject({ error: expect.stringContaining('Empty scope list') });
+  });
+
+  it('rejects unknown scope', () => {
+    const r = parseScopes('postgres');
+    expect(r).toMatchObject({ error: expect.stringContaining('Unknown scope(s): postgres') });
+  });
+
+  it('rejects mix of known and unknown, listing only the unknown', () => {
+    const r = parseScopes('pg,postgres,foo');
+    expect(r).toMatchObject({ error: expect.stringContaining('postgres, foo') });
+  });
+
+  it('returns undefined categories for explicit "all"', () => {
+    expect(parseScopes('all')).toEqual({ categories: undefined });
+  });
+
+  it('rejects "all" combined with other scopes', () => {
+    const r = parseScopes('all,kafka');
+    expect(r).toMatchObject({ error: expect.stringContaining(`'all' cannot be combined`) });
   });
 });
 

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -1,38 +1,39 @@
 import { describe, it, expect } from 'vitest';
 import { parseMcpQueryParams } from '../../src/transport.js';
+import { ServiceCategory } from '../../src/types.js';
 
 describe('parseMcpQueryParams', () => {
   describe('valid inputs', () => {
-    it('returns readOnly=false when no query params', () => {
+    it('returns readOnly=false and undefined categories when no query params', () => {
       const result = parseMcpQueryParams({}, false);
-      expect(result).toEqual({ options: { readOnly: false } });
+      expect(result).toEqual({ options: { readOnly: false, categories: undefined } });
     });
 
     it('returns readOnly=true when read_only=true', () => {
       const result = parseMcpQueryParams({ read_only: 'true' }, false);
-      expect(result).toEqual({ options: { readOnly: true } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
     });
 
     it('returns readOnly=false when read_only=false', () => {
       const result = parseMcpQueryParams({ read_only: 'false' }, false);
-      expect(result).toEqual({ options: { readOnly: false } });
+      expect(result).toEqual({ options: { readOnly: false, categories: undefined } });
     });
   });
 
   describe('server-level enforcement (env var)', () => {
     it('cannot override server readOnly=true with read_only=false', () => {
       const result = parseMcpQueryParams({ read_only: 'false' }, true);
-      expect(result).toEqual({ options: { readOnly: true } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
     });
 
     it('server readOnly=true with no query param stays true', () => {
       const result = parseMcpQueryParams({}, true);
-      expect(result).toEqual({ options: { readOnly: true } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
     });
 
     it('server readOnly=true with read_only=true stays true', () => {
       const result = parseMcpQueryParams({ read_only: 'true' }, true);
-      expect(result).toEqual({ options: { readOnly: true } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
     });
   });
 
@@ -68,13 +69,54 @@ describe('parseMcpQueryParams', () => {
     });
   });
 
+  describe('services scoping', () => {
+    it('parses ?services=kafka and implicitly includes core', () => {
+      const result = parseMcpQueryParams({ services_scope: 'kafka' }, false);
+      expect(result).toEqual({
+        options: {
+          readOnly: false,
+          categories: new Set([ServiceCategory.Core, ServiceCategory.Kafka]),
+        },
+      });
+    });
+
+    it('parses comma-separated scopes with whitespace', () => {
+      const result = parseMcpQueryParams({ services_scope: 'kafka, pg' }, false);
+      expect(result).toEqual({
+        options: {
+          readOnly: false,
+          categories: new Set([
+            ServiceCategory.Core,
+            ServiceCategory.Kafka,
+            ServiceCategory.Pg,
+          ]),
+        },
+      });
+    });
+
+    it('rejects unknown scope names', () => {
+      const result = parseMcpQueryParams({ services_scope: 'postgres' }, false);
+      expect(result).toMatchObject({ error: expect.stringContaining('Unknown scope(s): postgres') });
+    });
+
+    it('rejects empty services value', () => {
+      const result = parseMcpQueryParams({ services_scope: '' }, false);
+      expect(result).toMatchObject({ error: expect.stringContaining('Empty scope list') });
+    });
+
+    it('rejects array values for services_scope', () => {
+      const result = parseMcpQueryParams({ services_scope: ['kafka', 'pg'] }, false);
+      expect(result).toEqual({ error: 'Duplicate query parameter: services_scope' });
+    });
+  });
+
   describe('tenant isolation', () => {
     it('produces independent results for different inputs (no shared state)', () => {
       const orgA = parseMcpQueryParams({ read_only: 'true' }, false);
       const orgB = parseMcpQueryParams({}, false);
 
-      expect(orgA).toEqual({ options: { readOnly: true } });
-      expect(orgB).toEqual({ options: { readOnly: false } });
+      expect(orgA).toEqual({ options: { readOnly: true, categories: undefined } });
+      expect(orgB).toEqual({ options: { readOnly: false, categories: undefined } });
     });
   });
 });


### PR DESCRIPTION
  ## Summary
  - Adds an opt-in scope filter so users can load only the tool categories they need (`pg`, `kafka`, `application`, `integrations`), reducing context noise for AI agents that don't work across every Aiven product.
  - `core` is always included implicitly (project/service discovery is a prerequisite for every other tool). `all` is accepted as an explicit "load everything" sentinel; omitting the value behaves the same way (default = everything).
  - Two surfaces, one parser: 
    - **stdio**: `AIVEN_SERVICES_SCOPE=pg,kafka` env var
    - **HTTP**: `?services_scope=pg,kafka` query param
    
  ## Examples

-   https://mcp.aiven.live/mcp
-   https://mcp.aiven.live/mcp?services_scope=all
-   https://mcp.aiven.live/mcp?services_scope=kafka
-   https://mcp.aiven.live/mcp?services_scope=pg,kafka&read_only=true