### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-aiven",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for Aiven cloud data platform - manage PostgreSQL, Kafka, and other services",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version from `1.0.0` to `1.1.0` following the merge of search/limit filtering for list tools (minor bump for new backward-compatible feature)


Made with [Cursor](https://cursor.com)