### PR TITLE
fix: explicitly scope GitHub App token to Aiven-Open/mcp-aiven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ vars.VERSION_BOT_APP_ID }}
           private-key: ${{ secrets.VERSION_BOT_PRIVATE_KEY }}
+          owner: Aiven-Open
+          repositories: mcp-aiven
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add `owner: Aiven-Open` and `repositories: mcp-aiven` to the `actions/create-github-app-token@v2` step so the installation lookup is explicit rather than inferred from workflow context
- (Hopefully) Fixes "Integration not found" error in the Release workflow, assuming it's caused by `workflow_run` event context confusing the automatic installation lookup


Made with [Cursor](https://cursor.com)