### PR TITLE
feat: modify destructive tools [EVERSQL-1812]

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -73,6 +73,7 @@ tools:
     method: POST
     path: /project/{project}/service
     category: core
+    destructive: true
     append_list_picker_hint: true
     defaults:
       project_vpc_id: null

--- a/src/manifests/integrations.yaml
+++ b/src/manifests/integrations.yaml
@@ -20,6 +20,7 @@ tools:
     method: POST
     path: /project/{project}/integration
     category: integrations
+    destructive: true
     description: |
       Create a service integration between two Aiven services, or between an Aiven service and an external integration endpoint.
 
@@ -39,6 +40,7 @@ tools:
     method: PUT
     path: /project/{project}/integration/{integration_id}
     category: integrations
+    destructive: true
     description: |
       Update the configuration of an existing service integration.
 

--- a/src/manifests/kafka.yaml
+++ b/src/manifests/kafka.yaml
@@ -36,6 +36,7 @@ tools:
     method: POST
     path: /project/{project}/service/{service_name}/topic
     category: kafka
+    destructive: true
     description: |
       Create a Kafka topic.
 
@@ -66,6 +67,7 @@ tools:
     method: PUT
     path: /project/{project}/service/{service_name}/topic/{topic_name}
     category: kafka
+    destructive: true
 
   - name: aiven_kafka_topic_delete
     method: DELETE
@@ -104,6 +106,7 @@ tools:
     method: POST
     path: /project/{project}/service/{service_name}/kafka/rest/topics/{topic_name}/produce
     category: kafka
+    destructive: true
 
     description: |
       Produce messages into a Kafka topic.
@@ -173,6 +176,7 @@ tools:
     method: POST
     path: /project/{project}/service/{service_name}/connectors/{connector_name}/pause
     category: kafka
+    destructive: true
     description: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_resume_connector
@@ -185,6 +189,7 @@ tools:
     method: POST
     path: /project/{project}/service/{service_name}/connectors/{connector_name}/restart
     category: kafka
+    destructive: true
     description: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_delete_connector

--- a/src/manifests/pg.yaml
+++ b/src/manifests/pg.yaml
@@ -43,12 +43,14 @@ tools:
     method: POST
     path: /project/{project}/service/{service_name}/connection_pool
     category: pg
+    destructive: true
     description: *pg_connection_pool_plan_gate
 
   - name: aiven_pg_bouncer_update
     method: PUT
     path: /project/{project}/service/{service_name}/connection_pool/{pool_name}
     category: pg
+    destructive: true
     description: *pg_connection_pool_plan_gate
 
   - name: aiven_pg_bouncer_delete

--- a/src/tools/applications/handlers.ts
+++ b/src/tools/applications/handlers.ts
@@ -154,7 +154,7 @@ EXPOSE 3000
 CMD ["node", "dist/index.js"]
 \`\`\``,
         inputSchema: deployApplicationInput,
-        annotations: CREATE_ANNOTATIONS,
+        annotations: { ...CREATE_ANNOTATIONS, destructiveHint: true },
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         const {
@@ -315,7 +315,7 @@ Runtime errors in the app (500s, crashes, SSL errors) are NOT deploy failures â€
 
 The rebuild pulls the latest commit from the configured branch and rebuilds the Docker image. It does not change any service settings.`,
         inputSchema: redeployApplicationInput,
-        annotations: UPDATE_ANNOTATIONS,
+        annotations: { ...UPDATE_ANNOTATIONS, destructiveHint: true },
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         const { project, service_name: serviceName } = params as z.infer<

--- a/src/tools/kafka/handlers.ts
+++ b/src/tools/kafka/handlers.ts
@@ -26,7 +26,7 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
         title: 'Create Kafka Connect Connector',
         description: CREATE_CONNECTOR_DESCRIPTION,
         inputSchema: createConnectorInput,
-        annotations: CREATE_ANNOTATIONS,
+        annotations: { ...CREATE_ANNOTATIONS, destructiveHint: true },
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {
@@ -63,7 +63,7 @@ export function createKafkaCustomTools(client: AivenClient): ToolDefinition[] {
         title: 'Edit Kafka Connect Connector',
         description: EDIT_CONNECTOR_DESCRIPTION,
         inputSchema: editConnectorInput,
-        annotations: UPDATE_ANNOTATIONS,
+        annotations: { ...UPDATE_ANNOTATIONS, destructiveHint: true },
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {


### PR DESCRIPTION
# Summary
  - Mark additional tools as destructiveHint: true in tool annotations to signal clients that these operations modify or create resources
  - New tools marked destructive: aiven_service_create, aiven_kafka_topic_create, aiven_kafka_topic_update, aiven_kafka_topic_message_produce, aiven_kafka_connect_pause_connector,
  aiven_kafka_connect_restart_connector, aiven_service_integration_create, aiven_service_integration_update, aiven_pg_bouncer_create, aiven_pg_bouncer_update

 # Motivation

  MCP clients use destructiveHint annotations as a hint that a tool can modify or create resources. Clients may use this to prompt users for confirmation, but are not required to —
  it's advisory metadata. Previously, only aiven_service_update and DELETE-method tools were flagged, leaving create/produce/pause operations without the hint.

[EVERSQL-1812]
