### PR TITLE
fix: invalid secrets references in release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: publish
-    if: always() && (secrets.SLACK_WEBHOOK_PUBLISH_SUCCESS != '' || secrets.SLACK_WEBHOOK_PUBLISH_FAILURE != '')
+    if: always()
     steps:
       - name: Notify Slack (publish)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
         if: steps.release.outputs.pr != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_RELEASE_PR_OPENED }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
-          PR_TITLE: ${{ fromJSON(steps.release.outputs.pr).title }}
+          PR_NUMBER: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).number || '' }}
+          PR_TITLE: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).title || '' }}
         run: |
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "No Slack webhook configured, skipping notification"


### PR DESCRIPTION
## Summary

- **release.yml**: Guard `fromJSON()` calls with short-circuit expressions so they don't crash when `steps.release.outputs.pr` is empty (happens when a release PR is merged and release-please creates a release instead of a PR).
- **publish.yml**: Remove `secrets` from the job-level `if` expression -- `secrets` context is not allowed in `if` expressions and was making the entire workflow invalid. The shell script already handles missing webhooks gracefully.
