### PR TITLE
fix: remove invalid cache parameter from publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
           node-version: 22
           check-latest: true
           registry-url: https://registry.npmjs.org
-          cache: false
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       # Auth via npm trusted publishers (OIDC) — no NPM_TOKEN needed.


### PR DESCRIPTION
## Summary

- `actions/setup-node@v4` with `cache: false` fails with "Caching for 'false' is not supported". The `cache` parameter expects a package manager name or should be omitted. This was a latent bug from the old `publish.yml` that only surfaced now that the publish job actually runs.

## Test plan

- [ ] Merge and verify the publish job succeeds in the Release workflow


Made with [Cursor](https://cursor.com)