### PR TITLE
feature: add IP-keyed rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ MCP_HOST=http://localhost:3000 node dist/index.js
 | `AIVEN_SERVICES_SCOPE` | No | -- | Comma-separated scopes to expose (e.g. `kafka`, `pg,kafka`, or `all`). Valid: `all`, `core`, `pg`, `kafka`, `application`, `integrations`. `core` is always included. Omitting the var or setting `all` loads every tool. |
 | `MCP_HOST` | No | `https://mcp.aiven.live` | Override the OAuth protected resource host |
 | `MCP_TRANSPORT` | No | `stdio` | Set to `http` to start an HTTP server instead of stdio |
+| `MCP_HTTP_RATE_LIMIT_MAX` | No | `100` | Max requests per window on `POST /mcp` (HTTP transport). Applies independently to a per-bearer-token bucket and a per-source-IP bucket; whichever fills first returns 429. |
+| `MCP_HTTP_RATE_LIMIT_WINDOW_MS` | No | `60000` | Window length in milliseconds for `MCP_HTTP_RATE_LIMIT_MAX`. |
 
 In remote (HTTP) mode, `AIVEN_TOKEN` is not needed. Your MCP client sends your token as a Bearer token with each request.
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -48,7 +48,7 @@ function rateLimitExceededHandler(scope: string) {
   };
 }
 
-function createMcpPostRateLimit(
+function createMcpPostBearerRateLimit(
   cfg: HttpMcpRateLimitConfig,
   message: { error: string }
 ): ReturnType<typeof rateLimit> {
@@ -57,9 +57,30 @@ function createMcpPostRateLimit(
     limit: cfg.limit,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
-    keyGenerator: (req: Request) => mcpRequestKey(req),
+    keyGenerator: (req: Request) => bearerOrIpKey(req),
     message,
-    handler: rateLimitExceededHandler('mcp-post'),
+    handler: rateLimitExceededHandler('mcp-post-bearer'),
+  });
+}
+
+/**
+ * IP-keyed limiter applied alongside the bearer-keyed one. Catches
+ * bearer-rotation floods where each request uses a fresh fake token (which
+ * would otherwise get its own per-bearer bucket and bypass the cap). Uses
+ * the same limit/window — whichever bucket fills first triggers the 429.
+ */
+function createMcpPostIpRateLimit(
+  cfg: HttpMcpRateLimitConfig,
+  message: { error: string }
+): ReturnType<typeof rateLimit> {
+  return rateLimit({
+    windowMs: cfg.windowMs,
+    limit: cfg.limit,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    keyGenerator: (req: Request) => ipKeyGenerator(req.ip ?? '0.0.0.0'),
+    message,
+    handler: rateLimitExceededHandler('mcp-post-ip'),
   });
 }
 
@@ -73,7 +94,7 @@ function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   next();
 }
 
-function mcpRequestKey(req: Request): string {
+function bearerOrIpKey(req: Request): string {
   const auth = req.headers.authorization;
   if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
     const token = auth.slice(7).trim();
@@ -135,7 +156,11 @@ export function startHttpServer(
   }
   const mcpJsonParser = express.json({ limit: '512kb' });
 
-  const mcpPostRateLimit = createMcpPostRateLimit(config.rateLimit, {
+  const mcpPostIpRateLimit = createMcpPostIpRateLimit(config.rateLimit, {
+    error: 'Too many MCP requests from this client. Please wait before trying again.',
+  });
+
+  const mcpPostBearerRateLimit = createMcpPostBearerRateLimit(config.rateLimit, {
     error: 'Too many MCP requests. Please wait before trying again.',
   });
 
@@ -160,7 +185,7 @@ export function startHttpServer(
     res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
   });
 
-  app.post('/mcp', mcpPostRateLimit, authMiddleware, mcpJsonParser, (req: Request, res: Response) => {
+  app.post('/mcp', mcpPostIpRateLimit, mcpPostBearerRateLimit, authMiddleware, mcpJsonParser, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
       const parsed = parseMcpQueryParams(req.query as Record<string, unknown>, config.readOnly);
       if ('error' in parsed) {


### PR DESCRIPTION
  ## Summary
  
  Adds a second rate limiter on `POST /mcp` keyed on source IP, running alongside the existing per-token limiter. Both share the same `MCP_HTTP_RATE_LIMIT_MAX` cap (default 100/min); whichever bucket fills first returns `429`.

  This catches floods that the per-token limiter can't see, e.g. a client cycling through many tokens, or unauthenticated traffic before the auth check.

  ## Behavior
  
  | Scenario | Blocked at |
  |---|---|
  | One user, one token, one IP | 100/min (token bucket) |
  | Many tokens from one IP | 100/min (IP bucket) |
  | Multiple users sharing one IP | 100/min shared (IP bucket)  |

  Tunable via `MCP_HTTP_RATE_LIMIT_MAX` and `MCP_HTTP_RATE_LIMIT_WINDOW_MS`. Both env vars are now documented in the README.
