### PR TITLE
feat: mcp maintenance mode

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,10 @@ export function parseScopes(
   return { categories: set };
 }
 
+export function isMaintenanceMode(): boolean {
+  return process.env['MAINTENANCE_MODE'] === 'true';
+}
+
 export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
   const token = process.env['AIVEN_TOKEN'];
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -5,7 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Request, Response, NextFunction } from 'express';
-import { HOST, parseScopes } from './config.js';
+import { HOST, parseScopes, isMaintenanceMode } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
 import type { McpServerFactory, McpRequestOptions } from './types.js';
 
@@ -154,6 +154,21 @@ export function startHttpServer(
   if (config.trustProxy) {
     app.set('trust proxy', 1);
   }
+
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (!isMaintenanceMode()) {
+      next();
+      return;
+    }
+    if (req.path === '/health') {
+      res.json({ status: 'maintenance' });
+      return;
+    }
+    res.status(503).json({
+      error: 'Service is under maintenance. Please try again later.',
+    });
+  });
+
   const mcpJsonParser = express.json({ limit: '512kb' });
 
   const mcpPostIpRateLimit = createMcpPostIpRateLimit(config.rateLimit, {

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -3,6 +3,7 @@ import {
   loadConfig,
   loadHttpMcpRateLimit,
   httpTrustProxyEnabled,
+  isMaintenanceMode,
   parseScopes,
 } from '../../src/config.js';
 import { ServiceCategory } from '../../src/types.js';
@@ -211,5 +212,40 @@ describe('httpTrustProxyEnabled', () => {
 
     process.env['MCP_TRUST_PROXY'] = 'true';
     expect(httpTrustProxyEnabled()).toBe(true);
+  });
+});
+
+describe('isMaintenanceMode', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env['MAINTENANCE_MODE'];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should be false when MAINTENANCE_MODE is unset', () => {
+    expect(isMaintenanceMode()).toBe(false);
+  });
+
+  it('should be false when MAINTENANCE_MODE is "false"', () => {
+    process.env['MAINTENANCE_MODE'] = 'false';
+    expect(isMaintenanceMode()).toBe(false);
+  });
+
+  it('should be true when MAINTENANCE_MODE is "true"', () => {
+    process.env['MAINTENANCE_MODE'] = 'true';
+    expect(isMaintenanceMode()).toBe(true);
+  });
+
+  it('should be false for non-exact values like "TRUE" or "1"', () => {
+    process.env['MAINTENANCE_MODE'] = 'TRUE';
+    expect(isMaintenanceMode()).toBe(false);
+
+    process.env['MAINTENANCE_MODE'] = '1';
+    expect(isMaintenanceMode()).toBe(false);
   });
 });


### PR DESCRIPTION
# MCP Maintenance mode 

Add `MAINTENANCE_MODE` env var that returns 503 on all endpoints when set to "true". The `/health` endpoint returns `{status: "maintenance"}` to signal the process is alive but refusing traffic.