### PR TITLE
feat: rate limit behind cloudflare

### DIFF
--- a/src/cloudflare-ips.ts
+++ b/src/cloudflare-ips.ts
@@ -1,0 +1,63 @@
+import { BlockList, isIP } from 'node:net';
+
+const CLOUDFLARE_IPV4_CIDRS: readonly string[] = [
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/13',
+  '104.24.0.0/14',
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+];
+
+const CLOUDFLARE_IPV6_CIDRS: readonly string[] = [
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+];
+
+function addCidr(list: BlockList, cidr: string, family: 'ipv4' | 'ipv6'): void {
+  const slash = cidr.indexOf('/');
+  const addr = cidr.slice(0, slash);
+  const bits = parseInt(cidr.slice(slash + 1), 10);
+  list.addSubnet(addr, bits, family);
+}
+
+const cloudflareBlockList = ((): BlockList => {
+  const list = new BlockList();
+  for (const cidr of CLOUDFLARE_IPV4_CIDRS) addCidr(list, cidr, 'ipv4');
+  for (const cidr of CLOUDFLARE_IPV6_CIDRS) addCidr(list, cidr, 'ipv6');
+  return list;
+})();
+
+const IPV4_MAPPED_IPV6_PREFIX = '::ffff:';
+
+/** Strip `::ffff:` prefix from IPv4-mapped IPv6 (Node dual-stack sockets emit this form). */
+export function normalizePeerIp(ip: string | undefined): string | undefined {
+  if (ip === undefined) return undefined;
+  if (ip.toLowerCase().startsWith(IPV4_MAPPED_IPV6_PREFIX)) {
+    const v4 = ip.slice(IPV4_MAPPED_IPV6_PREFIX.length);
+    if (isIP(v4) === 4) return v4;
+  }
+  return ip;
+}
+
+/** True iff `ip` is a valid IP inside Cloudflare's published edge ranges. */
+export function isCloudflareAddress(ip: string | undefined): boolean {
+  if (ip === undefined) return false;
+  const family = isIP(ip);
+  if (family === 0) return false;
+  return cloudflareBlockList.check(ip, family === 4 ? 'ipv4' : 'ipv6');
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,12 +29,6 @@ export function loadHttpMcpRateLimit(): HttpMcpRateLimitConfig {
   };
 }
 
-/** When true, Express honors X-Forwarded-For for req.ip (use behind a reverse proxy). */
-export function httpTrustProxyEnabled(): boolean {
-  const v = process.env['MCP_TRUST_PROXY'];
-  return v === '1' || v === 'true';
-}
-
 /**
  * User-selectable scope names. Maps to ServiceCategory; `core` is always implicitly included
  * because every other category depends on `aiven_project_list` / `aiven_service_get` etc.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { createDocsTools } from './tools/docs/index.js';
 import { createServiceSearchTool } from './tools/service-search.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
 import type { ToolDefinition, McpRequestOptions } from './types.js';
-import { VERSION, API_ORIGIN, loadHttpMcpRateLimit, httpTrustProxyEnabled } from './config.js';
+import { VERSION, API_ORIGIN, loadHttpMcpRateLimit } from './config.js';
 import { createObservabilityContext } from './observability.js';
 import { readOnlyInstructions } from './prompts.js';
 
@@ -99,7 +99,6 @@ async function main(): Promise<void> {
       apiOrigin: API_ORIGIN,
       scopes: ['projects', 'services', 'accounts:read'],
       rateLimit: loadHttpMcpRateLimit(),
-      trustProxy: httpTrustProxyEnabled(),
       readOnly: config.readOnly,
     });
   } else {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { isIP } from 'node:net';
 import express from 'express';
 import rateLimit, { ipKeyGenerator, type Options } from 'express-rate-limit';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -8,6 +9,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { HOST, parseScopes, isMaintenanceMode } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
 import type { McpServerFactory, McpRequestOptions } from './types.js';
+import { isCloudflareAddress, normalizePeerIp } from './cloudflare-ips.js';
 
 export function createStdioTransport(): StdioServerTransport {
   return new StdioServerTransport();
@@ -18,7 +20,6 @@ export interface HttpServerConfig {
   apiOrigin: string;
   scopes: string[];
   rateLimit: HttpMcpRateLimitConfig;
-  trustProxy: boolean;
   readOnly: boolean;
 }
 
@@ -78,10 +79,19 @@ function createMcpPostIpRateLimit(
     limit: cfg.limit,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
-    keyGenerator: (req: Request) => ipKeyGenerator(req.ip ?? '0.0.0.0'),
+    keyGenerator: clientIpKey,
     message,
     handler: rateLimitExceededHandler('mcp-post-ip'),
   });
+}
+
+export function clientIpKey(req: Request): string {
+  const peer = normalizePeerIp(req.socket.remoteAddress);
+  const cf = req.headers['cf-connecting-ip'];
+  if (typeof cf === 'string' && isIP(cf) !== 0 && isCloudflareAddress(peer)) {
+    return ipKeyGenerator(cf);
+  }
+  return ipKeyGenerator(req.ip ?? peer ?? '0.0.0.0');
 }
 
 function authMiddleware(req: Request, res: Response, next: NextFunction): void {
@@ -94,7 +104,7 @@ function authMiddleware(req: Request, res: Response, next: NextFunction): void {
   next();
 }
 
-function bearerOrIpKey(req: Request): string {
+export function bearerOrIpKey(req: Request): string {
   const auth = req.headers.authorization;
   if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
     const token = auth.slice(7).trim();
@@ -102,7 +112,7 @@ function bearerOrIpKey(req: Request): string {
       return createHash('sha256').update(token).digest('hex');
     }
   }
-  return ipKeyGenerator(req.ip ?? '0.0.0.0');
+  return clientIpKey(req);
 }
 
 const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only', 'services_scope']);
@@ -151,9 +161,6 @@ export function startHttpServer(
   config: HttpServerConfig
 ): void {
   const app = express();
-  if (config.trustProxy) {
-    app.set('trust proxy', 1);
-  }
 
   app.use((req: Request, res: Response, next: NextFunction) => {
     if (!isMaintenanceMode()) {

--- a/tests/runtime/cloudflare-ips.test.ts
+++ b/tests/runtime/cloudflare-ips.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { isCloudflareAddress, normalizePeerIp } from '../../src/cloudflare-ips.js';
+
+describe('isCloudflareAddress', () => {
+  describe('IPv4 — inside Cloudflare ranges', () => {
+    it.each([
+      ['173.245.48.1', '173.245.48.0/20'],
+      ['103.21.244.50', '103.21.244.0/22'],
+      ['141.101.64.0', '141.101.64.0/18'],
+      ['162.158.255.255', '162.158.0.0/15'],
+      ['104.16.0.0', '104.16.0.0/13'],
+      ['172.64.1.1', '172.64.0.0/13'],
+    ])('accepts %s (in %s)', (ip) => {
+      expect(isCloudflareAddress(ip)).toBe(true);
+    });
+  });
+
+  describe('IPv4 — outside Cloudflare ranges', () => {
+    it.each([
+      '173.245.47.255', // one below 173.245.48.0/20
+      '173.245.64.0', // one above 173.245.48.0/20
+      '8.8.8.8', // Google DNS
+      '1.1.1.1', // Cloudflare DNS — public service IP, NOT in edge ranges
+      '127.0.0.1', // localhost
+      '10.0.0.1', // private
+      '192.168.1.1', // private
+      '0.0.0.0',
+      '255.255.255.255',
+    ])('rejects %s', (ip) => {
+      expect(isCloudflareAddress(ip)).toBe(false);
+    });
+  });
+
+  describe('IPv6 — inside Cloudflare ranges', () => {
+    it.each([
+      ['2400:cb00::1', '2400:cb00::/32'],
+      ['2606:4700::1', '2606:4700::/32'],
+      ['2a06:98c0::1', '2a06:98c0::/29'],
+    ])('accepts %s (in %s)', (ip) => {
+      expect(isCloudflareAddress(ip)).toBe(true);
+    });
+  });
+
+  describe('IPv6 — outside Cloudflare ranges', () => {
+    it.each([
+      '2001:db8::1', // documentation range
+      '::1', // loopback
+      'fe80::1', // link-local
+      '2607:f8b0::1', // Google
+    ])('rejects %s', (ip) => {
+      expect(isCloudflareAddress(ip)).toBe(false);
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it.each([undefined, '', 'not-an-ip', '999.999.999.999', '173.245.48', '::ffff:not-ip'])(
+      'rejects %s',
+      (ip) => {
+        expect(isCloudflareAddress(ip)).toBe(false);
+      }
+    );
+  });
+});
+
+describe('normalizePeerIp', () => {
+  it('strips ::ffff: prefix from IPv4-mapped IPv6', () => {
+    expect(normalizePeerIp('::ffff:173.245.48.1')).toBe('173.245.48.1');
+  });
+
+  it('handles uppercase ::FFFF: prefix', () => {
+    expect(normalizePeerIp('::FFFF:1.2.3.4')).toBe('1.2.3.4');
+  });
+
+  it('leaves non-mapped IPv6 unchanged', () => {
+    expect(normalizePeerIp('2606:4700::1')).toBe('2606:4700::1');
+  });
+
+  it('leaves IPv4 unchanged', () => {
+    expect(normalizePeerIp('173.245.48.1')).toBe('173.245.48.1');
+  });
+
+  it('returns undefined for undefined', () => {
+    expect(normalizePeerIp(undefined)).toBeUndefined();
+  });
+
+  it('does not strip ::ffff: when remainder is not a valid IPv4', () => {
+    expect(normalizePeerIp('::ffff:not-an-ip')).toBe('::ffff:not-an-ip');
+  });
+});
+
+describe('integration: normalizePeerIp + isCloudflareAddress', () => {
+  it('IPv4-mapped IPv6 of a CF IP is accepted after normalization', () => {
+    const peer = normalizePeerIp('::ffff:162.158.1.1');
+    expect(isCloudflareAddress(peer)).toBe(true);
+  });
+
+  it('IPv4-mapped IPv6 of a non-CF IP is rejected after normalization', () => {
+    const peer = normalizePeerIp('::ffff:8.8.8.8');
+    expect(isCloudflareAddress(peer)).toBe(false);
+  });
+});

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
   loadHttpMcpRateLimit,
-  httpTrustProxyEnabled,
   isMaintenanceMode,
   parseScopes,
 } from '../../src/config.js';
@@ -187,31 +186,6 @@ describe('loadHttpMcpRateLimit', () => {
     process.env['MCP_HTTP_RATE_LIMIT_MAX'] = '-1';
 
     expect(loadHttpMcpRateLimit()).toEqual({ windowMs: 60_000, limit: 100 });
-  });
-});
-
-describe('httpTrustProxyEnabled', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env['MCP_TRUST_PROXY'];
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it('should be false when MCP_TRUST_PROXY is unset', () => {
-    expect(httpTrustProxyEnabled()).toBe(false);
-  });
-
-  it('should be true when MCP_TRUST_PROXY is 1 or true', () => {
-    process.env['MCP_TRUST_PROXY'] = '1';
-    expect(httpTrustProxyEnabled()).toBe(true);
-
-    process.env['MCP_TRUST_PROXY'] = 'true';
-    expect(httpTrustProxyEnabled()).toBe(true);
   });
 });
 

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -1,6 +1,25 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
-import { parseMcpQueryParams } from '../../src/transport.js';
+import type { Request } from 'express';
+import { parseMcpQueryParams, clientIpKey, bearerOrIpKey } from '../../src/transport.js';
 import { ServiceCategory } from '../../src/types.js';
+
+function makeReq(opts: {
+  ip?: string;
+  headers?: Record<string, string | undefined>;
+  peerIp?: string;
+}): Request {
+  return {
+    ip: opts.ip,
+    headers: opts.headers ?? {},
+    socket: { remoteAddress: opts.peerIp },
+  } as unknown as Request;
+}
+
+const CF_EDGE_IP = '162.158.1.1';
+const NON_CF_PEER = '10.0.0.1';
+
+const sha = (s: string): string => createHash('sha256').update(s).digest('hex');
 
 describe('parseMcpQueryParams', () => {
   describe('valid inputs', () => {
@@ -118,5 +137,295 @@ describe('parseMcpQueryParams', () => {
       expect(orgA).toEqual({ options: { readOnly: true, categories: undefined } });
       expect(orgB).toEqual({ options: { readOnly: false, categories: undefined } });
     });
+  });
+});
+
+describe('clientIpKey', () => {
+  describe('peer is a Cloudflare edge IP (header is trusted)', () => {
+    it('uses CF-Connecting-IP when peer is in CF range', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: CF_EDGE_IP,
+          ip: CF_EDGE_IP,
+          headers: { 'cf-connecting-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain('203.0.113.7');
+      expect(key).not.toContain(CF_EDGE_IP);
+    });
+
+    it('different real client IPs from same CF edge produce different keys', () => {
+      const userA = clientIpKey(
+        makeReq({
+          peerIp: CF_EDGE_IP,
+          headers: { 'cf-connecting-ip': '198.51.100.1' },
+        })
+      );
+      const userB = clientIpKey(
+        makeReq({
+          peerIp: CF_EDGE_IP,
+          headers: { 'cf-connecting-ip': '198.51.100.2' },
+        })
+      );
+      expect(userA).not.toBe(userB);
+    });
+
+    it('same real client IP via different CF edges produces the same key', () => {
+      const viaEdge1 = clientIpKey(
+        makeReq({
+          peerIp: '162.158.1.1',
+          headers: { 'cf-connecting-ip': '198.51.100.1' },
+        })
+      );
+      const viaEdge2 = clientIpKey(
+        makeReq({
+          peerIp: '104.16.0.1',
+          headers: { 'cf-connecting-ip': '198.51.100.1' },
+        })
+      );
+      expect(viaEdge1).toBe(viaEdge2);
+    });
+
+    it('peer in CF IPv6 range is also accepted', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: '2606:4700::1',
+          headers: { 'cf-connecting-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain('203.0.113.7');
+    });
+
+    it('IPv4-mapped IPv6 peer (::ffff:CF_IP) is recognized as CF', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: `::ffff:${CF_EDGE_IP}`,
+          headers: { 'cf-connecting-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain('203.0.113.7');
+    });
+
+    it('CF-Connecting-IP that is not a valid IP is ignored even if peer is CF', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: CF_EDGE_IP,
+          ip: '203.0.113.99',
+          headers: { 'cf-connecting-ip': 'not-an-ip' },
+        })
+      );
+      expect(key).toContain('203.0.113.99');
+      expect(key).not.toContain('not-an-ip');
+    });
+
+    it('empty CF-Connecting-IP is ignored even if peer is CF', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: CF_EDGE_IP,
+          ip: '203.0.113.99',
+          headers: { 'cf-connecting-ip': '' },
+        })
+      );
+      expect(key).toContain('203.0.113.99');
+    });
+  });
+
+  describe('peer is NOT a Cloudflare edge IP (header is ignored)', () => {
+    it('forged CF-Connecting-IP from non-CF peer is ignored — uses req.ip', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'cf-connecting-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain(NON_CF_PEER);
+      expect(key).not.toContain('203.0.113.7');
+    });
+
+    it('attacker rotating fake CF-Connecting-IP gets same bucket every time', () => {
+      const k1 = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'cf-connecting-ip': '1.1.1.1' },
+        })
+      );
+      const k2 = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'cf-connecting-ip': '2.2.2.2' },
+        })
+      );
+      const k3 = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'cf-connecting-ip': '3.3.3.3' },
+        })
+      );
+      expect(k1).toBe(k2);
+      expect(k2).toBe(k3);
+    });
+
+    it('peer just outside CF range (e.g., 173.245.47.255 — one below 173.245.48.0/20) is rejected', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: '173.245.47.255',
+          ip: '173.245.47.255',
+          headers: { 'cf-connecting-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain('173.245.47.255');
+      expect(key).not.toContain('203.0.113.7');
+    });
+  });
+
+  describe('local / self-hosted (no proxy)', () => {
+    it('localhost IPv4 uses req.ip', () => {
+      const key = clientIpKey(makeReq({ peerIp: '127.0.0.1', ip: '127.0.0.1' }));
+      expect(key).toContain('127.0.0.1');
+    });
+
+    it('localhost IPv6 uses req.ip', () => {
+      const key = clientIpKey(makeReq({ peerIp: '::1', ip: '::1' }));
+      expect(key.length).toBeGreaterThan(0);
+    });
+
+    it('public client direct (no CF) uses req.ip', () => {
+      const key = clientIpKey(makeReq({ peerIp: '203.0.113.7', ip: '203.0.113.7' }));
+      expect(key).toContain('203.0.113.7');
+    });
+
+    it('falls back to peer IP when req.ip is missing', () => {
+      const key = clientIpKey(makeReq({ peerIp: '203.0.113.7' }));
+      expect(key).toContain('203.0.113.7');
+    });
+
+    it('falls back to 0.0.0.0 when both req.ip and peer are missing', () => {
+      const key = clientIpKey(makeReq({}));
+      expect(key).toBe('0.0.0.0');
+    });
+  });
+
+  describe('hardening', () => {
+    it('does not read X-Forwarded-For (legacy XFF must not affect bucket key)', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'x-forwarded-for': '203.0.113.7' },
+        })
+      );
+      expect(key).toContain(NON_CF_PEER);
+      expect(key).not.toContain('203.0.113.7');
+    });
+
+    it('does not trust X-Real-IP', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'x-real-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).not.toContain('203.0.113.7');
+    });
+
+    it('does not trust True-Client-IP', () => {
+      const key = clientIpKey(
+        makeReq({
+          peerIp: NON_CF_PEER,
+          ip: NON_CF_PEER,
+          headers: { 'true-client-ip': '203.0.113.7' },
+        })
+      );
+      expect(key).not.toContain('203.0.113.7');
+    });
+  });
+});
+
+describe('bearerOrIpKey', () => {
+  it('uses sha256(token) when a Bearer token is present', () => {
+    const key = bearerOrIpKey(
+      makeReq({
+        ip: '10.0.0.1',
+        headers: { authorization: 'Bearer secret-token-abc' },
+      })
+    );
+    expect(key).toBe(sha('secret-token-abc'));
+  });
+
+  it('does not log the raw token (key is a hex hash, not the token itself)', () => {
+    const key = bearerOrIpKey(
+      makeReq({ headers: { authorization: 'Bearer secret-token-abc' } })
+    );
+    expect(key).not.toContain('secret-token-abc');
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('different tokens produce different bucket keys', () => {
+    const k1 = bearerOrIpKey(makeReq({ headers: { authorization: 'Bearer t1' } }));
+    const k2 = bearerOrIpKey(makeReq({ headers: { authorization: 'Bearer t2' } }));
+    expect(k1).not.toBe(k2);
+  });
+
+  it('falls back to clientIpKey (CF-Connecting-IP) when Authorization header missing and peer is CF', () => {
+    const key = bearerOrIpKey(
+      makeReq({
+        peerIp: CF_EDGE_IP,
+        headers: { 'cf-connecting-ip': '203.0.113.7' },
+      })
+    );
+    expect(key).toContain('203.0.113.7');
+  });
+
+  it('falls back to clientIpKey when Authorization scheme is not Bearer', () => {
+    const key = bearerOrIpKey(
+      makeReq({
+        peerIp: CF_EDGE_IP,
+        ip: NON_CF_PEER,
+        headers: {
+          authorization: 'Basic dXNlcjpwYXNz',
+          'cf-connecting-ip': '203.0.113.7',
+        },
+      })
+    );
+    expect(key).toContain('203.0.113.7');
+    expect(key).not.toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('falls back to clientIpKey when Bearer token is empty', () => {
+    const key = bearerOrIpKey(
+      makeReq({
+        peerIp: CF_EDGE_IP,
+        headers: { authorization: 'Bearer ', 'cf-connecting-ip': '203.0.113.7' },
+      })
+    );
+    expect(key).toContain('203.0.113.7');
+  });
+
+  it('falls back to clientIpKey when Bearer token is whitespace-only', () => {
+    const key = bearerOrIpKey(
+      makeReq({
+        peerIp: CF_EDGE_IP,
+        headers: { authorization: 'Bearer    ', 'cf-connecting-ip': '203.0.113.7' },
+      })
+    );
+    expect(key).toContain('203.0.113.7');
+  });
+
+  it('the bearer-keyed bucket is independent from the IP-keyed bucket', () => {
+    const bearerKey = bearerOrIpKey(
+      makeReq({
+        peerIp: CF_EDGE_IP,
+        headers: { authorization: 'Bearer t1', 'cf-connecting-ip': '203.0.113.7' },
+      })
+    );
+    const ipKey = clientIpKey(
+      makeReq({ peerIp: CF_EDGE_IP, headers: { 'cf-connecting-ip': '203.0.113.7' } })
+    );
+    expect(bearerKey).not.toBe(ipKey);
   });
 });


### PR DESCRIPTION
Rate limits now apply to the actual end client, not the Cloudflare edge.

Behind Cloudflare, the limiter buckets by the real client IP (read from `CF-Connecting-IP`, but only when the connection genuinely came from a Cloudflare edge).

Removing the no-longer-needed `MCP_TRUST_PROXY` env var.