### PR TITLE
feat: show building instead of rebuilding for newly created services

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -74,6 +74,7 @@ tools:
     path: /project/{project}/service
     category: core
     destructive: true
+    enrich_service_state: assume-recent
     append_list_picker_hint: true
     defaults:
       project_vpc_id: null
@@ -92,7 +93,7 @@ tools:
       This tool returns a `service` object with the following fields:
       - service_name: Name of the service
       - service_type: Service type (e.g. `pg`, `kafka`)
-      - state: Provisioning lifecycle (e.g. `BUILDING`, `REBUILDING`, `RUNNING`; not always `RUNNING` immediately after create)
+      - state: Provisioning lifecycle value (often `REBUILDING` right after create). When present, `state_display` is `BUILDING` for initial provisioning.
       - plan: Selected plan identifier
       - cloud_name: Cloud region identifier where the service runs
 
@@ -100,6 +101,7 @@ tools:
     method: GET
     path: /project/{project}/service/{service_name}
     category: core
+    enrich_service_state: from-create-time
     exclude_params: [include_secrets]
     description: |
       Get service information. `project` must be a valid Aiven project name from `aiven_project_list`.
@@ -107,7 +109,7 @@ tools:
 
       **Returns:** A `service` object; exact keys depend on `service_type` (Postgres example below). Not an exhaustive listing.
 
-      **Core:** `service_name`, `service_type`, `service_type_description`, `state`, `plan`, optional `plan_price_usd`, `cloud_name`, `cloud_description`, `tags`, `create_time`, `update_time`, `termination_protection`, sizing (`disk_space_mb`, `node_count`, node CPU/memory, `metadata` such as `pg_version`), `features`, `maintenance`, `service_notifications`, `tech_emails`, `project_vpc_id`, **`service_integrations`**, **`server_group`**, `cmk_id`, `group_list`, `is_cluster_plan`.
+      **Core:** `service_name`, `service_type`, `service_type_description`, `state`, optional `state_display` (`BUILDING` when `state` is `REBUILDING` and the service was created within the last 30 minutes — initial provisioning, not a rebuild), `plan`, optional `plan_price_usd`, `cloud_name`, `cloud_description`, `tags`, `create_time`, `update_time`, `termination_protection`, sizing (`disk_space_mb`, `node_count`, node CPU/memory, `metadata` such as `pg_version`), `features`, `maintenance`, `service_notifications`, `tech_emails`, `project_vpc_id`, **`service_integrations`**, **`server_group`**, `cmk_id`, `group_list`, `is_cluster_plan`.
 
       **Connectivity:** **`components`** (hosts, ports, roles such as primary/replica), **`connection_info`**, **`service_uri`**, **`service_uri_params`**. Sensitive values appear as **`[REDACTED]`** through this MCP.
 

--- a/src/shared/service-state.ts
+++ b/src/shared/service-state.ts
@@ -1,0 +1,56 @@
+/** Matches Aiven Console: newly created services report REBUILDING during initial provisioning. */
+export const INITIAL_BUILD_WINDOW_MS = 30 * 60 * 1000;
+
+export function isInitialProvisioning(
+  state: string,
+  createTime: string | undefined,
+  options?: { assumeRecent?: boolean }
+): boolean {
+  if (state !== 'REBUILDING') return false;
+  if (options?.assumeRecent) return true;
+  if (!createTime) return false;
+  const created = new Date(createTime).getTime();
+  if (Number.isNaN(created)) return false;
+  return Date.now() - created < INITIAL_BUILD_WINDOW_MS;
+}
+
+/**
+ * Adds `state_display` when API `state` is REBUILDING but the service is still in its initial build.
+ * Raw `state` is left unchanged so it stays aligned with the Aiven API.
+ */
+export function enrichServiceRecord(
+  service: Record<string, unknown>,
+  options?: { assumeRecent?: boolean }
+): Record<string, unknown> {
+  const state = typeof service['state'] === 'string' ? service['state'] : undefined;
+  const createTime = typeof service['create_time'] === 'string' ? service['create_time'] : undefined;
+  if (!state || !isInitialProvisioning(state, createTime, options)) {
+    return service;
+  }
+  return {
+    ...service,
+    state_display: 'BUILDING',
+  };
+}
+
+export function enrichServiceResponse(
+  data: Record<string, unknown>,
+  options?: { assumeRecent?: boolean }
+): Record<string, unknown> {
+  const service = data['service'];
+  if (service && typeof service === 'object') {
+    return { ...data, service: enrichServiceRecord(service as Record<string, unknown>, options) };
+  }
+  const services = data['services'];
+  if (Array.isArray(services)) {
+    return {
+      ...data,
+      services: services.map((item) =>
+        item && typeof item === 'object'
+          ? enrichServiceRecord(item as Record<string, unknown>, options)
+          : item
+      ),
+    };
+  }
+  return data;
+}

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -5,6 +5,7 @@ import { errorMessage } from '../errors.js';
 import { redactSensitiveData } from '../security.js';
 import { wrapUntrustedResponse } from '../untrusted.js';
 import { applyResponseFilter, extendSchemaWithSearch, stripSearchParams } from './response-filter.js';
+import { enrichServiceResponse } from '../shared/service-state.js';
 
 function extractPathParams(path: string): Set<string> {
   return new Set(
@@ -112,9 +113,15 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
         const data = await executeRequest(client, config, argsWithoutReasoning, pathParams, opts);
         const redacted = redactSensitiveData(data);
 
-        const filtered = config.responseFilter
+        let filtered = config.responseFilter
           ? applyResponseFilter(redacted, config.responseFilter, search, limit, offset)
           : redacted;
+
+        if (config.enrichServiceState) {
+          filtered = enrichServiceResponse(filtered, {
+            assumeRecent: config.enrichServiceState === 'assume-recent',
+          });
+        }
 
         return toolSuccess(wrapUntrustedResponse(filtered));
       } catch (err) {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -10,6 +10,7 @@ import type {
   JsonSchema,
   ResponseFilterConfig,
   HandlerContext,
+  ServiceStateEnrichment,
 } from '../types.js';
 import {
   ServiceCategory,
@@ -34,6 +35,7 @@ interface ManifestEntry {
   destructive?: boolean;
   defaults?: Record<string, unknown>;
   response_filter?: ResponseFilterConfig;
+  enrich_service_state?: ServiceStateEnrichment;
 }
 
 interface ManifestFile {
@@ -176,6 +178,7 @@ export function loadApiTools(client: AivenClient): ToolDefinition[] {
         annotations: deriveAnnotations(entry.method, entry.readOnly, entry.destructive),
         defaults: entry.defaults,
         responseFilter: entry.response_filter,
+        enrichServiceState: entry.enrich_service_state,
       },
       client
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,9 @@ export interface ResponseFilterConfig {
 
 export type ToolSpec = ApiToolConfig;
 
+/** Enrich REBUILDING → state_display BUILDING for newly created services (see service-state.ts). */
+export type ServiceStateEnrichment = 'from-create-time' | 'assume-recent';
+
 export interface ApiToolConfig {
   name: string;
   title: string;
@@ -166,6 +169,7 @@ export interface ApiToolConfig {
   annotations: ToolAnnotations;
   defaults?: Record<string, unknown> | undefined;
   responseFilter?: ResponseFilterConfig | undefined;
+  enrichServiceState?: ServiceStateEnrichment | undefined;
 }
 
 export interface ServiceConnectionInfo {

--- a/tests/runtime/api-tool.test.ts
+++ b/tests/runtime/api-tool.test.ts
@@ -86,6 +86,33 @@ describe('createApiTool', () => {
     expect(client.get).toHaveBeenCalledWith('/project', expect.objectContaining({ toolName: 'aiven_list_projects' }));
   });
 
+  it('should add state_display for recently created REBUILDING services', async () => {
+    const client = createMockClient({
+      service: {
+        state: 'REBUILDING',
+        create_time: new Date().toISOString(),
+      },
+    });
+    const tool = createApiTool(
+      {
+        ...baseConfig,
+        path: '/project/{project}/service/{service_name}',
+        inputSchema: z.object({ project: z.string(), service_name: z.string() }).strict(),
+        enrichServiceState: 'from-create-time',
+      },
+      client
+    );
+
+    const result = await tool.handler({ project: 'p', service_name: 's' });
+    const parsed = parseResult(result);
+
+    expect(parsed['service']).toEqual({
+      state: 'REBUILDING',
+      create_time: expect.any(String),
+      state_display: 'BUILDING',
+    });
+  });
+
   it('should replace path params in URL', async () => {
     const config: ApiToolConfig = {
       ...baseConfig,

--- a/tests/runtime/service-state.test.ts
+++ b/tests/runtime/service-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  INITIAL_BUILD_WINDOW_MS,
+  isInitialProvisioning,
+  enrichServiceRecord,
+  enrichServiceResponse,
+} from '../../src/shared/service-state.js';
+
+describe('service-state', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('isInitialProvisioning', () => {
+    it('returns true for REBUILDING within the initial build window', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-27T12:00:00Z'));
+      const createTime = new Date('2026-05-27T11:45:00Z').toISOString();
+      expect(isInitialProvisioning('REBUILDING', createTime)).toBe(true);
+    });
+
+    it('returns false for REBUILDING outside the initial build window', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-27T12:00:00Z'));
+      const createTime = new Date(
+        Date.now() - INITIAL_BUILD_WINDOW_MS - 60_000
+      ).toISOString();
+      expect(isInitialProvisioning('REBUILDING', createTime)).toBe(false);
+    });
+
+    it('returns true when assumeRecent is set', () => {
+      expect(isInitialProvisioning('REBUILDING', undefined, { assumeRecent: true })).toBe(true);
+    });
+
+    it('returns false for RUNNING', () => {
+      expect(isInitialProvisioning('RUNNING', new Date().toISOString())).toBe(false);
+    });
+  });
+
+  describe('enrichServiceRecord', () => {
+    it('adds state_display BUILDING for recent REBUILDING services', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-27T12:00:00Z'));
+      const enriched = enrichServiceRecord({
+        state: 'REBUILDING',
+        create_time: new Date('2026-05-27T11:50:00Z').toISOString(),
+      });
+      expect(enriched).toEqual({
+        state: 'REBUILDING',
+        create_time: '2026-05-27T11:50:00.000Z',
+        state_display: 'BUILDING',
+      });
+    });
+
+    it('leaves state unchanged when not initial provisioning', () => {
+      const service = { state: 'RUNNING', create_time: new Date().toISOString() };
+      expect(enrichServiceRecord(service)).toBe(service);
+    });
+  });
+
+  describe('enrichServiceResponse', () => {
+    it('enriches nested service object', () => {
+      const data = enrichServiceResponse(
+        { service: { state: 'REBUILDING' } },
+        { assumeRecent: true }
+      );
+      expect(data).toEqual({
+        service: { state: 'REBUILDING', state_display: 'BUILDING' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
The Aiven API has no BUILDING state for deployed services. New services show REBUILDING during initial provisioning. 
I took the same approach as [we added in the Console](https://github.com/aiven/aiven-core/pull/71568):
For such services, that was created less than 30 minutes ago, show BUILDING instead. (MCP adds `state_display: "BUILDING`".)