### PR TITLE
fix(descriptions): correct cross-tool refs, restore plan-gate summaries, ground new descriptions in OpenAPI [EVERSQL-1822]

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -180,6 +180,10 @@ tools:
     path: /project/{project}/service/{service_name}/query/activity
     category: core
     readOnly: true
+    description: |
+      Fetch current queries / connections for the service. Body params: `limit` (1–5000, default 100), `offset` (default 0), `order_by` (default `client_id:desc`).
+
+      Returns `queries`: an array where each item describes one connection. Item fields are engine-specific. Always-available identifiers include `pid`, `state`, `query`, `query_duration`, `query_start`, `client_addr`, `client_port`, `application_name`, `backend_start`, `backend_type`, `wait_event`, `wait_event_type`.
 
   - name: aiven_service_metrics_fetch
     method: POST
@@ -255,3 +259,7 @@ tools:
     response_filter:
       key: events
       search_fields: [actor, event_type, event_desc, service_name]
+    description: |
+      Get project event log entries.
+
+      Returns `events`: an array of entries with `id` (event identifier), `time` (ISO 8601 UTC), `actor` (initiator of the event), `event_type` (event type identifier), `event_desc` (event description), and `service_name`.

--- a/src/manifests/kafka.yaml
+++ b/src/manifests/kafka.yaml
@@ -68,11 +68,19 @@ tools:
     path: /project/{project}/service/{service_name}/topic/{topic_name}
     category: kafka
     destructive: true
+    description: |
+      Update a Kafka topic.
+
+      Top-level body params: `partitions` (1–1000000), `replication` (≥1), `owner_user_group_id`, `tags`, `topic_description`. Topic-level Kafka settings go under **`config`** (e.g. `config.cleanup_policy`, `config.retention_ms`, `config.retention_bytes`, `config.min_insync_replicas`, `config.compression_type`, `config.max_message_bytes`, tiered-storage `config.local_retention_ms` / `config.local_retention_bytes`, etc.).
+
+      Response is empty on success.
 
   - name: aiven_kafka_topic_delete
     method: DELETE
     path: /project/{project}/service/{service_name}/topic/{topic_name}
     category: kafka
+    description: |
+      Delete a Kafka topic. Response is empty on success.
 
   - name: aiven_kafka_topic_message_list
     method: POST
@@ -125,7 +133,7 @@ tools:
     response_filter:
       key: plugins
       search_fields: [plugin_type]
-    description: *kafka_connect_plan_gate
+    description_prefix: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_list
     method: GET
@@ -177,26 +185,26 @@ tools:
     path: /project/{project}/service/{service_name}/connectors/{connector_name}/pause
     category: kafka
     destructive: true
-    description: *kafka_connect_plan_gate
+    description_prefix: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_resume_connector
     method: POST
     path: /project/{project}/service/{service_name}/connectors/{connector_name}/resume
     category: kafka
-    description: *kafka_connect_plan_gate
+    description_prefix: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_restart_connector
     method: POST
     path: /project/{project}/service/{service_name}/connectors/{connector_name}/restart
     category: kafka
     destructive: true
-    description: *kafka_connect_plan_gate
+    description_prefix: *kafka_connect_plan_gate
 
   - name: aiven_kafka_connect_delete_connector
     method: DELETE
     path: /project/{project}/service/{service_name}/connectors/{connector_name}
     category: kafka
-    description: *kafka_connect_plan_gate
+    description_prefix: *kafka_connect_plan_gate
 
   - name: aiven_kafka_schema_registry_subjects
     method: GET
@@ -206,8 +214,16 @@ tools:
     response_filter:
       key: subjects
       search_fields: [_string]
+    description: |
+      List Schema Registry subjects on a Kafka service.
+
+      Returns `subjects`: an array of subject name strings.
 
   - name: aiven_kafka_schema_registry_subject_version_get
     method: GET
     path: /project/{project}/service/{service_name}/kafka/schema/subjects/{subject_name}/versions/{version_id}
     category: kafka
+    description: |
+      Get a specific version of a Schema Registry subject. Path params: `subject_name` and `version_id`.
+
+      Returns a `version` object with: `id` (integer schema id), `subject` (string), `version` (integer), `schema` (string, max 1 MiB), `schemaType` (`AVRO`, `JSON`, or `PROTOBUF`), and optional `references` (array of `{ name, subject, version }` linking other subjects).

--- a/src/manifests/pg.yaml
+++ b/src/manifests/pg.yaml
@@ -20,6 +20,10 @@ tools:
     response_filter:
       key: extensions
       search_fields: [name]
+    description: |
+      List PostgreSQL extensions that can be loaded with `CREATE EXTENSION` in this service.
+
+      Returns `extensions`: an array of `{ name, default_version, versions }`, where `versions` is an array of installable version strings.
 
   - name: aiven_pg_service_query_statistics
     method: POST
@@ -44,17 +48,17 @@ tools:
     path: /project/{project}/service/{service_name}/connection_pool
     category: pg
     destructive: true
-    description: *pg_connection_pool_plan_gate
+    description_prefix: *pg_connection_pool_plan_gate
 
   - name: aiven_pg_bouncer_update
     method: PUT
     path: /project/{project}/service/{service_name}/connection_pool/{pool_name}
     category: pg
     destructive: true
-    description: *pg_connection_pool_plan_gate
+    description_prefix: *pg_connection_pool_plan_gate
 
   - name: aiven_pg_bouncer_delete
     method: DELETE
     path: /project/{project}/service/{service_name}/connection_pool/{pool_name}
     category: pg
-    description: *pg_connection_pool_plan_gate
+    description_prefix: *pg_connection_pool_plan_gate

--- a/src/tools/pg/descriptions.ts
+++ b/src/tools/pg/descriptions.ts
@@ -3,7 +3,7 @@ import { MAX_ROWS, DEFAULT_LIMIT } from './query.js';
 
 export const OPTIMIZE_QUERY_DESCRIPTION = `Get AI-powered query optimization using EverSQL.
 
-**IMPORTANT:** Requires account_id. Get it by calling get_project first -
+**IMPORTANT:** Requires account_id. Get it by calling aiven_project_get first -
 the account_id is in the response at project.account_id.
 
 Analyzes your SQL query and returns:
@@ -14,8 +14,8 @@ Analyzes your SQL query and returns:
 Works best with SELECT queries but also helps with INSERT/UPDATE/DELETE.
 
 **Example workflow:**
-1. Call get_project(project="my-project") -> get account_id from response
-2. Call optimize_query(account_id="...", query="SELECT * FROM orders WHERE status = 'pending'")`;
+1. Call aiven_project_get(project="my-project") -> get account_id from response
+2. Call aiven_pg_optimize_query(account_id="...", query="SELECT * FROM orders WHERE status = 'pending'")`;
 
 export const PG_READ_DESCRIPTION = `Execute a read-only SQL query against an Aiven PostgreSQL service.
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -29,6 +29,7 @@ interface ManifestEntry {
   path: string;
   category: string;
   description?: string;
+  description_prefix?: string;
   append_list_picker_hint?: boolean;
   readOnly?: boolean;
   destructive?: boolean;
@@ -159,6 +160,9 @@ export function loadApiTools(client: AivenClient): ToolDefinition[] {
     }
 
     let description = entry.description ?? schemaEntry.description;
+    if (entry.description_prefix) {
+      description = `${entry.description_prefix.trimEnd()}\n\n${description}`;
+    }
     if (entry.append_list_picker_hint) {
       description = `${description}\n\n${TOOL_LIST_PICKER_SUFFIX}`;
     }


### PR DESCRIPTION

- Fix tool-name references in pg descriptions (`get_project` → `aiven_project_get`, `optimize_query` → `aiven_pg_optimize_query`).
- Add `description_prefix` manifest field that prepends to the OpenAPI summary instead of replacing it; switch the 5 Kafka Connect plan-gate tools and 3 PgBouncer plan-gate tools from `description:` to `description_prefix:` so they keep both the warning and the API verb summary.
- Add OpenAPI-grounded descriptions to 7 tools that previously fell through to the raw OpenAPI summary: `aiven_service_query_activity`, `aiven_project_get_event_logs`, `aiven_kafka_topic_update`, `aiven_kafka_topic_delete`, `aiven_kafka_schema_registry_subjects`, `aiven_kafka_schema_registry_subject_version_get`, `aiven_pg_service_available_extensions`.

[EVERSQL-1822]