### PR TITLE
fix: mask only password in connection URIs instead of full redaction

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -109,7 +109,7 @@ tools:
 
       **Core:** `service_name`, `service_type`, `service_type_description`, `state`, `plan`, optional `plan_price_usd`, `cloud_name`, `cloud_description`, `tags`, `create_time`, `update_time`, `termination_protection`, sizing (`disk_space_mb`, `node_count`, node CPU/memory, `metadata` such as `pg_version`), `features`, `maintenance`, `service_notifications`, `tech_emails`, `project_vpc_id`, **`service_integrations`**, **`server_group`**, `cmk_id`, `group_list`, `is_cluster_plan`.
 
-      **Connectivity:** **`components`** (hosts, ports, roles such as primary/replica), **`connection_info`**, **`service_uri`**, **`service_uri_params`**. Sensitive values appear as **`[REDACTED]`** through this MCP.
+      **Connectivity:** **`components`** (hosts, ports, roles such as primary/replica), **`connection_info`**, **`service_uri`**, **`service_uri_params`**. Connection URIs are returned with only the password masked (e.g. `postgresql://avnadmin:<REDACTED_PASSWORD>@host:port/defaultdb?sslmode=require`); share this URI with the user and point them to the Aiven Console (https://console.aiven.io/) for the real password. Standalone secrets (passwords, tokens, certificates) still appear as **`[REDACTED]`**.
 
       **PostgreSQL / engine-specific:** `databases`, **`backups`**, **`connection_pools`**, replica/standby entries in `connection_info`, **`users`**, **`user_config`** (e.g. backups, `ip_filter`, engine tuning).
 

--- a/src/security.ts
+++ b/src/security.ts
@@ -1,4 +1,11 @@
 export const REDACTED_PLACEHOLDER = '[REDACTED]';
+export const REDACTED_PASSWORD_PLACEHOLDER = '<REDACTED_PASSWORD>';
+
+const URI_WITH_PASSWORD = /([a-z][a-z0-9+.-]*:\/\/[^:/?#@\s]+:)([^/?#\s'"]+)(@[^/?#@\s'"]+)/gi;
+
+export function maskUriPassword(value: string): string {
+  return value.replace(URI_WITH_PASSWORD, `$1${REDACTED_PASSWORD_PLACEHOLDER}$3`);
+}
 
 export const REDACTED_FIELDS = new Set([
   'password', 'access_key', 'access_secret', 'secret_key', 'api_key',
@@ -10,7 +17,9 @@ export const REDACTED_FIELDS = new Set([
 ]);
 
 const REDACTED_KEY = /(?:^|\.)(password|token|secret|api_key|access_key|access_secret|secret_key|auth_token|private_key|client_secret|connection_string|sasl_password|keystore_password|truststore_password|.*_uri|.*_url|ca_cert|client_cert|client_key|ssl_cert|ssl_key|certificate|.*_cert|.*_key|.*_ca|.*_certificate|.*_pem)$/i;
-const SENSITIVE_VALUE = /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----|^[a-z]+:\/\/[^:]+:[^@]+@/i;
+
+const CERT_OR_KEY_BLOB = /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----/i;
+const URI_WITH_CREDENTIALS = /[a-z][a-z0-9+.-]*:\/\/[^:/@\s]+:[^@\s]+@/i;
 
 const SCRUB_PATTERNS: { pattern: RegExp; replacement: string }[] = [
   {
@@ -21,10 +30,6 @@ const SCRUB_PATTERNS: { pattern: RegExp; replacement: string }[] = [
     pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
     replacement: '[REDACTED_KEY]',
   },
-  {
-    pattern: /[a-z]+:\/\/[^:]+:[^@\s]+@[^\s'"]+/gi,
-    replacement: '[REDACTED_URI]',
-  },
 ];
 
 export function scrubSensitiveValues(value: string): string {
@@ -32,21 +37,25 @@ export function scrubSensitiveValues(value: string): string {
   for (const { pattern, replacement } of SCRUB_PATTERNS) {
     result = result.replace(pattern, replacement);
   }
-  return result;
+  return maskUriPassword(result);
 }
 
 export function redactSensitiveData<T>(data: T): T {
   if (data == null) return data;
   if (typeof data === 'string') {
-    return (SENSITIVE_VALUE.test(data) ? REDACTED_PLACEHOLDER : data) as T;
+    if (CERT_OR_KEY_BLOB.test(data)) return REDACTED_PLACEHOLDER as T;
+    return maskUriPassword(data) as T;
   }
   if (typeof data !== 'object') return data;
 
   const json = JSON.stringify(data, (key, value: unknown) => {
     if (!key) return value;
 
+    if (typeof value === 'string' && URI_WITH_CREDENTIALS.test(value)) {
+      return maskUriPassword(value);
+    }
     if (REDACTED_KEY.test(key)) return REDACTED_PLACEHOLDER;
-    if (typeof value === 'string' && SENSITIVE_VALUE.test(value)) return REDACTED_PLACEHOLDER;
+    if (typeof value === 'string' && CERT_OR_KEY_BLOB.test(value)) return REDACTED_PLACEHOLDER;
 
     return value;
   });

--- a/tests/runtime/observability.test.ts
+++ b/tests/runtime/observability.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { redactReasoningField } from '../../src/observability.js';
-import { REDACTED_PLACEHOLDER } from '../../src/security.js';
+import { REDACTED_PASSWORD_PLACEHOLDER } from '../../src/security.js';
 
 describe('redactReasoningField', () => {
   it('returns null for undefined', () => {
@@ -21,16 +21,18 @@ describe('redactReasoningField', () => {
     );
   });
 
-  it('redacts string that is a bare sensitive URI', () => {
+  it('masks only the password in a bare connection URI', () => {
     expect(redactReasoningField('postgres://admin:secret@host:5432/db')).toBe(
-      REDACTED_PLACEHOLDER
+      `postgres://admin:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
     );
   });
 
-  it('does not redact string with embedded URI (redaction is value-level, not substring)', () => {
+  it('masks the password in an embedded URI (substring-level for URIs)', () => {
     const input = 'connect to postgres://admin:secret@host:5432/db';
     const result = redactReasoningField(input);
-    expect(result).toBe(input);
+    expect(result).toBe(
+      `connect to postgres://admin:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
+    );
   });
 
   it('serializes object reasoning via JSON.stringify', () => {

--- a/tests/runtime/redact.test.ts
+++ b/tests/runtime/redact.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   redactSensitiveData,
+  maskUriPassword,
   REDACTED_PLACEHOLDER,
+  REDACTED_PASSWORD_PLACEHOLDER,
   REDACTED_FIELDS,
 } from '../../src/security.js';
 
@@ -22,25 +24,39 @@ describe('redactSensitiveData', () => {
     expect(result.name).toBe('test');
   });
 
-  it('should redact connection_uri fields', () => {
+  it('should mask only the password in connection_uri fields', () => {
     const input = { connection_uri: 'postgres://user:pass@host:5432/db' };
     const result = redactSensitiveData(input);
 
-    expect(result.connection_uri).toBe(REDACTED_PLACEHOLDER);
+    expect(result.connection_uri).toBe(
+      `postgres://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
+    );
   });
 
-  it('should redact postgres URIs in string values', () => {
+  it('should mask only the password in postgres URIs in string values', () => {
     const input = { uri: 'postgres://user:pass@host:5432/db' };
     const result = redactSensitiveData(input);
 
-    expect(result.uri).toBe(REDACTED_PLACEHOLDER);
+    expect(result.uri).toBe(`postgres://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`);
   });
 
-  it('should redact kafka URIs in string values', () => {
+  it('should mask only the password in kafka URIs in string values', () => {
     const input = { uri: 'kafka://user:pass@host:9092' };
     const result = redactSensitiveData(input);
 
-    expect(result.uri).toBe(REDACTED_PLACEHOLDER);
+    expect(result.uri).toBe(`kafka://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:9092`);
+  });
+
+  it('should preserve the documented PG service_uri shape with password masked', () => {
+    const input = {
+      service_uri:
+        'postgresql://avnadmin:realsecret@customer-intelligence-pg-eversql-sandbox.a.aivencloud.com:22202/defaultdb?sslmode=require',
+    };
+    const result = redactSensitiveData(input);
+
+    expect(result.service_uri).toBe(
+      'postgresql://avnadmin:<REDACTED_PASSWORD>@customer-intelligence-pg-eversql-sandbox.a.aivencloud.com:22202/defaultdb?sslmode=require'
+    );
   });
 
   it('should redact certificate fields', () => {
@@ -122,14 +138,64 @@ describe('sensitive field patterns', () => {
     expect(REDACTED_FIELDS.has('plan')).toBe(false);
   });
 
-  it('should redact sensitive URIs in values via redactSensitiveData', () => {
-    // Test via behavior rather than directly calling removed helpers
-    expect(redactSensitiveData('postgres://user:pass@host:5432/db')).toBe(REDACTED_PLACEHOLDER);
-    expect(redactSensitiveData('postgresql://admin:secret@localhost/mydb')).toBe(
-      REDACTED_PLACEHOLDER
+  it('should mask only the password in sensitive URIs via redactSensitiveData', () => {
+    expect(redactSensitiveData('postgres://user:pass@host:5432/db')).toBe(
+      `postgres://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
     );
-    expect(redactSensitiveData('kafka://user:pass@host:9092')).toBe(REDACTED_PLACEHOLDER);
-    expect(redactSensitiveData('https://user:pass@api.example.com')).toBe(REDACTED_PLACEHOLDER);
+    expect(redactSensitiveData('postgresql://admin:secret@localhost/mydb')).toBe(
+      `postgresql://admin:${REDACTED_PASSWORD_PLACEHOLDER}@localhost/mydb`
+    );
+    expect(redactSensitiveData('kafka://user:pass@host:9092')).toBe(
+      `kafka://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:9092`
+    );
+    expect(redactSensitiveData('https://user:pass@api.example.com')).toBe(
+      `https://user:${REDACTED_PASSWORD_PLACEHOLDER}@api.example.com`
+    );
+  });
+
+  it('maskUriPassword masks only the password and leaves non-URIs untouched', () => {
+    expect(maskUriPassword('postgres://user:pass@host:5432/db')).toBe(
+      `postgres://user:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
+    );
+    expect(maskUriPassword('not a uri')).toBe('not a uri');
+    expect(maskUriPassword('https://api.aiven.io/v1/project')).toBe(
+      'https://api.aiven.io/v1/project'
+    );
+  });
+
+  it('fully masks passwords that contain @ (no fragment leak)', () => {
+    expect(maskUriPassword('mysql://avnadmin:p@ssw0rd@host:12691/db')).toBe(
+      `mysql://avnadmin:${REDACTED_PASSWORD_PLACEHOLDER}@host:12691/db`
+    );
+    expect(maskUriPassword('postgres://avnadmin:AVNS_a@b@c@host:5432/db')).toBe(
+      `postgres://avnadmin:${REDACTED_PASSWORD_PLACEHOLDER}@host:5432/db`
+    );
+    expect(redactSensitiveData({ service_uri: 'redis://default:s3cr@t@redis-host:6379' })).toEqual(
+      { service_uri: `redis://default:${REDACTED_PASSWORD_PLACEHOLDER}@redis-host:6379` }
+    );
+  });
+
+  it('does not mask @ that appears only in the query string', () => {
+    expect(maskUriPassword('https://u:p@host/cb?next=a@b.com')).toBe(
+      `https://u:${REDACTED_PASSWORD_PLACEHOLDER}@host/cb?next=a@b.com`
+    );
+  });
+
+  it('leaves a credential-less URI (user but no password) untouched', () => {
+    expect(maskUriPassword('postgres://user@host:5432/db')).toBe('postgres://user@host:5432/db');
+  });
+
+  it('masks the password for an IPv6 host URI', () => {
+    expect(maskUriPassword('postgres://avnadmin:pw@[2001:db8::1]:5432/db')).toBe(
+      `postgres://avnadmin:${REDACTED_PASSWORD_PLACEHOLDER}@[2001:db8::1]:5432/db`
+    );
+  });
+
+  it('should still fully redact standalone secrets and certificates', () => {
+    expect(redactSensitiveData({ password: 'secret123' }).password).toBe(REDACTED_PLACEHOLDER);
+    expect(
+      redactSensitiveData('-----BEGIN CERTIFICATE-----\nblob\n-----END CERTIFICATE-----')
+    ).toBe(REDACTED_PLACEHOLDER);
   });
 
   it('should not redact URLs without credentials', () => {


### PR DESCRIPTION
Return connection URIs with only the password masked (e.g. postgresql://avnadmin:<REDACTED_PASSWORD>@host:22202/defaultdb?sslmode=require) instead of fully redacting them, so users can see the host/port/user/db and just need to drop in the real password from the Aiven Console to connect (e.g. via psql). Standalone secrets, tokens, and certs stay fully redacted.


<img width="1705" height="697" alt="Screenshot 2026-06-02 at 11 16 36" src="https://github.com/user-attachments/assets/73e9f775-ec2b-4fc0-81a8-7797b836e8c6" />
