### PR TITLE
fix: use fileURLToPath for Windows-compatible manifest path resolution

### DIFF
--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import type { AivenClient } from '../client.js';
 import type {
@@ -94,7 +95,7 @@ function deriveAnnotations(
 }
 
 function loadManifests(): ManifestEntry[] {
-  const manifestDir = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'manifests');
+  const manifestDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'manifests');
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- trusted internal path
   const files = fs
     .readdirSync(manifestDir)


### PR DESCRIPTION
## Summary

Fixes #109 — `mcp-aiven` crashes on Windows with `ENOENT: no such file or directory, scandir 'C:\C:\Users\...\dist\manifests'` due to a doubled drive letter in path resolution.

## Root Cause

In `src/tools/registry.ts`, the manifest directory is resolved using:

```ts
const manifestDir = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'manifests');
```

On Windows, `new URL(import.meta.url).pathname` returns `/C:/Users/...` (with a leading forward slash per the URL spec). When `path.dirname()` processes this on Windows, it produces `c:\C:\Users\...` — doubling the drive letter.

## Fix

Replace `new URL(import.meta.url).pathname` with `fileURLToPath(import.meta.url)` from `node:url`, which correctly handles the `file://` URL-to-path conversion on all platforms (stripping the leading slash on Windows, handling encoded characters, etc.).

## Changes

- Added `import { fileURLToPath } from 'node:url';`
- Changed manifest path resolution to use `fileURLToPath(import.meta.url)` instead of `new URL(import.meta.url).pathname`

## Testing

- Verified on Windows 11, Node.js v22.22.2
- The `dist/manifests` directory exists and contains the expected YAML files
- After patching, the server connects successfully via stdio transport