### PR TITLE
fix: reject conflicting kafka connector fields when source_service is set

### DIFF
--- a/src/tools/kafka/descriptions.ts
+++ b/src/tools/kafka/descriptions.ts
@@ -4,7 +4,7 @@ const CONNECTOR_SUFFIX = `**Kafka Connect plan gate — call \`aiven_service_get
 
 **Plans that typically include Kafka Connect:** \`startup-*\` (e.g. \`startup-2\`, \`startup-4\`), \`business-*\`, \`premium-*\`. A 403 mentioning Connect being **disabled** is typically a **plan** limitation, not token RBAC.
 
-When \`source_service\` is provided, connection credentials (hostname, port, user, password) are automatically resolved from that Aiven service — no need to look up or provide passwords manually.
+When \`source_service\` is provided, connection credentials (hostname, port, user, password) are automatically resolved from that Aiven service — no need to look up or provide passwords manually. Do not also pass connection fields (host/port/user/password/url) when using \`source_service\`.
 
 Supports Debezium CDC connectors (PostgreSQL, MySQL), JDBC source/sink, and any connector class. Extra configuration fields are passed through as-is.
 

--- a/src/tools/kafka/helpers.ts
+++ b/src/tools/kafka/helpers.ts
@@ -73,9 +73,14 @@ export async function buildConnectorConfig(
 
     const fieldMapping = detectFieldMapping(connectorClass);
     if (fieldMapping) {
+      const conflicts = Object.keys(fieldMapping).filter((k) => config[k] !== undefined);
+      if (conflicts.length > 0) {
+        throw new Error(
+          `When 'source_service' is set, the tool injects connection fields from the source service. ` +
+            `Remove these user-provided field(s) or omit 'source_service': ${conflicts.join(', ')}.`
+        );
+      }
       for (const [configKey, infoField] of Object.entries(fieldMapping)) {
-        if (config[configKey] !== undefined) continue;
-
         if (infoField === '_jdbc_url') {
           config[configKey] = buildJdbcUrl(connInfo);
         } else {

--- a/tests/runtime/kafka-helpers.test.ts
+++ b/tests/runtime/kafka-helpers.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AivenClient } from '../../src/client.js';
+import { buildConnectorConfig } from '../../src/tools/kafka/helpers.js';
+
+const SERVICE_CONN = {
+  host: 'pg-host.aiven.io',
+  port: '12345',
+  user: 'avnadmin',
+  password: 'secret-password',
+  dbname: 'defaultdb',
+};
+
+function createMockClient(): AivenClient {
+  const getMock = vi.fn().mockResolvedValue({
+    service: { service_uri_params: { ...SERVICE_CONN } },
+  });
+  return { get: getMock } as unknown as AivenClient;
+}
+
+describe('buildConnectorConfig', () => {
+  it('passes through extra config and maps connector_class', async () => {
+    const config = await buildConnectorConfig(createMockClient(), {
+      project: 'p',
+      service_name: 'kafka',
+      connector_class: 'io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector',
+      name: 'sink',
+      'topic.prefix': 'cdc',
+      'flush.size': '1000',
+    });
+
+    expect(config['connector.class']).toBe('io.aiven.kafka.connect.s3.AivenKafkaConnectS3SinkConnector');
+    expect(config['topic.prefix']).toBe('cdc');
+    expect(config['flush.size']).toBe('1000');
+    // Routing keys are not forwarded to the connector config
+    expect(config['project']).toBeUndefined();
+    expect(config['connector_class']).toBeUndefined();
+  });
+
+  it('injects connection fields from source_service for postgres connectors', async () => {
+    const config = await buildConnectorConfig(createMockClient(), {
+      project: 'p',
+      service_name: 'kafka',
+      connector_class: 'io.debezium.connector.postgresql.PostgresConnector',
+      name: 'cdc',
+      source_service: 'my-pg',
+    });
+
+    expect(config['database.hostname']).toBe('pg-host.aiven.io');
+    expect(config['database.port']).toBe(12345);
+    expect(config['database.user']).toBe('avnadmin');
+    expect(config['database.password']).toBe('secret-password');
+    expect(config['database.dbname']).toBe('defaultdb');
+  });
+
+  it('rejects the call if the caller also supplies a mapped connection field', async () => {
+    await expect(
+      buildConnectorConfig(createMockClient(), {
+        project: 'p',
+        service_name: 'kafka',
+        connector_class: 'io.debezium.connector.postgresql.PostgresConnector',
+        name: 'cdc',
+        source_service: 'my-pg',
+        // Attacker-supplied host — must not be combined with injected credentials
+        'database.hostname': 'evil.attacker.com',
+      })
+    ).rejects.toThrow(/database\.hostname/);
+  });
+
+  it('rejects conflicting JDBC connection fields when source_service is set', async () => {
+    await expect(
+      buildConnectorConfig(createMockClient(), {
+        project: 'p',
+        service_name: 'kafka',
+        connector_class: 'io.aiven.connect.jdbc.JdbcSourceConnector',
+        name: 'jdbc',
+        source_service: 'my-pg',
+        'connection.url': 'jdbc:postgresql://evil.attacker.com:5432/db',
+      })
+    ).rejects.toThrow(/connection\.url/);
+  });
+
+  it('allows caller-supplied connection fields when source_service is omitted', async () => {
+    const config = await buildConnectorConfig(createMockClient(), {
+      project: 'p',
+      service_name: 'kafka',
+      connector_class: 'io.debezium.connector.postgresql.PostgresConnector',
+      name: 'cdc',
+      'database.hostname': 'my-own-host.example.com',
+      'database.password': 'my-own-password',
+    });
+
+    expect(config['database.hostname']).toBe('my-own-host.example.com');
+    expect(config['database.password']).toBe('my-own-password');
+  });
+});


### PR DESCRIPTION
When `source_service` is set, `aiven_kafka_connect_create_connector` fills in the connection fields (host, port, user, password) from that service. If the caller also passed one of those fields, the tool used to keep the caller's value while still injecting the rest, producing an unexpected config merge. Now the tool owns all mapped fields when source_service is set, and rejects the call with a clear error if any are also supplied by the caller.