### PR TITLE
fix: support marketplace mcp authorization

### DIFF
--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -1,0 +1,9 @@
+const MARKETPLACE_TENANTS = new Set(['aws', 'azure', 'gcp']);
+
+export function resolveAuthorizationServer(marketplace: unknown, apiOrigin: string): string {
+  const tenant = typeof marketplace === 'string' ? marketplace.trim().toLowerCase() : undefined;
+  if (tenant && MARKETPLACE_TENANTS.has(tenant)) {
+    return `${apiOrigin}/${tenant}`;
+  }
+  return apiOrigin;
+}

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -10,6 +10,7 @@ import { HOST, parseScopes, isMaintenanceMode } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
 import type { McpServerFactory, McpRequestOptions } from './types.js';
 import { isCloudflareAddress, normalizePeerIp } from './cloudflare-ips.js';
+import { resolveAuthorizationServer } from './marketplace.js';
 import { captureException } from './instrumentation/index.js';
 
 export function createStdioTransport(): StdioServerTransport {
@@ -191,24 +192,28 @@ export function startHttpServer(
     res.json({ status: 'ok' });
   });
 
-  app.get('/.well-known/oauth-protected-resource', (_req: Request, res: Response) => {
+  const protectedResource = (resourceSuffix: string) => (req: Request, res: Response): void => {
+    const tenant = typeof req.params['tenant'] === 'string' ? req.params['tenant'].toLowerCase() : undefined;
     res.json({
-      resource: HOST,
-      authorization_servers: [config.apiOrigin],
+      resource: `${HOST}${resourceSuffix}${tenant ? `/${tenant}` : ''}`,
+      authorization_servers: [resolveAuthorizationServer(tenant, config.apiOrigin)],
       scopes_supported: config.scopes,
       bearer_methods_supported: ['header'],
     });
-  });
+  };
+  app.get('/.well-known/oauth-protected-resource', protectedResource(''));
+  app.get('/.well-known/oauth-protected-resource/mcp', protectedResource('/mcp'));
+  app.get('/.well-known/oauth-protected-resource/mcp/:tenant', protectedResource('/mcp'));
 
-  app.get('/mcp', (_req: Request, res: Response) => {
+  app.get(['/mcp', '/mcp/:tenant'], (_req: Request, res: Response) => {
     res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
   });
 
-  app.delete('/mcp', (_req: Request, res: Response) => {
+  app.delete(['/mcp', '/mcp/:tenant'], (_req: Request, res: Response) => {
     res.status(405).set('Allow', 'POST').json({ error: 'Method Not Allowed' });
   });
 
-  app.post('/mcp', mcpPostIpRateLimit, mcpPostBearerRateLimit, authMiddleware, mcpJsonParser, (req: Request, res: Response) => {
+  app.post(['/mcp', '/mcp/:tenant'], mcpPostIpRateLimit, mcpPostBearerRateLimit, authMiddleware, mcpJsonParser, (req: Request, res: Response) => {
     void (async (): Promise<void> => {
       const parsed = parseMcpQueryParams(req.query as Record<string, unknown>, config.readOnly);
       if ('error' in parsed) {

--- a/tests/runtime/marketplace.test.ts
+++ b/tests/runtime/marketplace.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAuthorizationServer } from '../../src/marketplace.js';
+
+describe('resolveAuthorizationServer', () => {
+  const API = 'https://api.aiven.io';
+
+  it('advertises a tenant-scoped issuer for gcp', () => {
+    expect(resolveAuthorizationServer('gcp', API)).toBe('https://api.aiven.io/gcp');
+  });
+
+  it('advertises a tenant-scoped issuer for aws', () => {
+    expect(resolveAuthorizationServer('aws', API)).toBe('https://api.aiven.io/aws');
+  });
+
+  it('advertises a tenant-scoped issuer for azure', () => {
+    expect(resolveAuthorizationServer('azure', API)).toBe('https://api.aiven.io/azure');
+  });
+
+  it('falls back to the default issuer when marketplace is absent', () => {
+    expect(resolveAuthorizationServer(undefined, API)).toBe(API);
+  });
+
+  it('falls back to the default issuer for the aiven tenant (no dedicated console path)', () => {
+    expect(resolveAuthorizationServer('aiven', API)).toBe(API);
+  });
+
+  it('falls back to the default issuer for unknown values (no path injection)', () => {
+    expect(resolveAuthorizationServer('../evil', API)).toBe(API);
+    expect(resolveAuthorizationServer('not-a-tenant', API)).toBe(API);
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(resolveAuthorizationServer('  GCP  ', API)).toBe('https://api.aiven.io/gcp');
+  });
+
+  it('ignores a non-string (duplicated/array) value', () => {
+    expect(resolveAuthorizationServer(['gcp', 'aws'], API)).toBe(API);
+  });
+});

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -37,6 +37,7 @@ describe('parseMcpQueryParams', () => {
       const result = parseMcpQueryParams({ read_only: 'false' }, false);
       expect(result).toEqual({ options: { readOnly: false, categories: undefined } });
     });
+
   });
 
   describe('server-level enforcement (env var)', () => {


### PR DESCRIPTION
Read the marketplace tenant from the MCP URL path (/mcp/<tenant>) and advertise a tenant-scoped authorization server in protected-resource metadata, so gcp/aws/azure users are sent to their branded Console for OAuth login. The tenant lives in the path (not a query param) so it survives resource canonicalization across clients (Claude, Gemini)