### PR TITLE
feat: add aiven_service_connection_info tool gated by allow_secrets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,11 +10,12 @@ import { createPgCustomTools } from './tools/pg/index.js';
 import { createApplicationTools } from './tools/applications/index.js';
 import { createDocsTools } from './tools/docs/index.js';
 import { createServiceSearchTool } from './tools/service-search.js';
+import { createConnectionInfoTool } from './tools/connection-info.js';
 import { createStdioTransport, startHttpServer } from './transport.js';
 import type { ToolDefinition, McpRequestOptions } from './types.js';
 import { VERSION, API_ORIGIN, loadHttpMcpRateLimit } from './config.js';
 import { createObservabilityContext } from './observability.js';
-import { readOnlyInstructions } from './prompts.js';
+import { readOnlyInstructions, connectionInfoInstructions } from './prompts.js';
 import { instrumentServer, flushAndExit } from './instrumentation/index.js';
 
 /** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
@@ -87,9 +88,16 @@ async function main(): Promise<void> {
       tools = tools.filter((t) => allowed.has(t.category));
     }
 
-    const serverOptions = options.readOnly
-      ? ([{ instructions: readOnlyInstructions(transport) }] as const)
-      : ([] as const);
+    if (options.allowSecrets) {
+      tools = [...tools, ...createConnectionInfoTool(client)];
+    }
+
+    const instructions: string[] = [];
+    if (options.readOnly) instructions.push(readOnlyInstructions(transport));
+    if (transport === 'http') instructions.push(connectionInfoInstructions(options.allowSecrets));
+
+    const serverOptions =
+      instructions.length > 0 ? ([{ instructions: instructions.join(' ') }] as const) : ([] as const);
 
     const server = new McpServer({ name: 'mcp-aiven', version: VERSION }, ...serverOptions);
     registerTools(server, tools);
@@ -108,7 +116,9 @@ async function main(): Promise<void> {
       readOnly: config.readOnly,
     });
   } else {
-    const server = instrumentServer(createMcpServer({ readOnly: config.readOnly, categories: config.categories }));
+    const server = instrumentServer(
+      createMcpServer({ readOnly: config.readOnly, categories: config.categories, allowSecrets: false })
+    );
     await server.connect(createStdioTransport());
     console.error('mcp-aiven: Server connected and ready');
   }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -12,6 +12,15 @@ export function readOnlyInstructions(transport: 'stdio' | 'http'): string {
   );
 }
 
+export function connectionInfoInstructions(allowSecrets: boolean): string {
+  return allowSecrets
+    ? 'Connection info is redacted as `[REDACTED]` in all tools except ' +
+        '`aiven_service_connection_info` — use that tool to get live credentials.'
+    : 'Connection info is redacted as `[REDACTED]` and cannot be retrieved through ' +
+        'this connector. This is expected — do not guess credentials or call tools not ' +
+        'in your tool list. To enable, reconfigure the connector with `allow_secrets=true`.';
+}
+
 export const TOOL_LIST_PICKER_SUFFIX =
   '**Lists & picks:** When turning this tool’s output into user choices, curate **2–5** options at a time unless they explicitly ask for the full catalog. ' +
   'In **Claude Code**, prefer `AskUserQuestion` when appropriate.';

--- a/src/shared/service-info.ts
+++ b/src/shared/service-info.ts
@@ -39,21 +39,36 @@ export async function getProjectCaCert(
   return data.certificate;
 }
 
-export async function getServiceConnectionInfo(
+export async function getServiceWithSecrets<T>(
   client: AivenClient,
   project: string,
   serviceName: string,
   opts?: RequestOptions
-): Promise<ServiceConnectionInfo> {
-  const data = await client.get<ServiceResponse>(
+): Promise<T> {
+  const data = await client.get<{ service: T }>(
     `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}`,
     {
       ...opts,
       query: { ...opts?.query, include_secrets: true },
     }
   );
+  return data.service;
+}
 
-  const params = data.service.service_uri_params;
+export async function getServiceConnectionInfo(
+  client: AivenClient,
+  project: string,
+  serviceName: string,
+  opts?: RequestOptions
+): Promise<ServiceConnectionInfo> {
+  const service = await getServiceWithSecrets<ServiceResponse['service']>(
+    client,
+    project,
+    serviceName,
+    opts
+  );
+
+  const params = service.service_uri_params;
   if (!params) {
     throw new Error(`No connection info available for service ${serviceName}. Ensure the service is running.`);
   }

--- a/src/tools/connection-info.ts
+++ b/src/tools/connection-info.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+import type { AivenClient } from '../client.js';
+import type { ToolDefinition, ToolResult, HandlerContext } from '../types.js';
+import { ServiceCategory, READ_ONLY_ANNOTATIONS, toolSuccess, toolError } from '../types.js';
+import { errorMessage } from '../errors.js';
+import { wrapUntrustedResponse } from '../untrusted.js';
+import { getProjectCaCert, getServiceWithSecrets } from '../shared/service-info.js';
+
+const inputSchema = z.object({
+  project: z.string().describe('Aiven project name (from `aiven_project_list`).'),
+  service_name: z.string().describe('Service name (from `aiven_service_list`).'),
+});
+
+const DESCRIPTION = `Return LIVE connection credentials for an Aiven PostgreSQL or Kafka service so they can be wired into an application.
+
+⚠️ SECURITY: This returns real credentials (passwords, connection URIs, and for Kafka mTLS the client certificate and private key) directly into this conversation; they will be stored in the chat transcript. Only use it when the user is explicitly building or configuring an application and has asked for connection details. Prefer writing them into the app's environment/secret store rather than echoing them back to the user.
+
+Returns the minimum needed to connect:
+- PostgreSQL: \`service_uri\`, \`service_uri_params\` (host, port, user, password, dbname), \`ca_cert\`.
+- Kafka: \`service_uri\` (bootstrap servers), \`users\` (SASL password and/or mTLS \`access_cert\`+\`access_key\`), \`ca_cert\`.
+
+Connecting: TLS is required. Verify against \`ca_cert\` (Aiven uses a self-signed project CA) — never disable verification or use the system trust store. For node-postgres, drop \`sslmode\` from the URL and pass \`ssl: { ca, rejectUnauthorized: true }\`.
+
+This tool is only available when the connector was configured with \`allow_secrets=true\`.`;
+
+interface ServiceUser {
+  username?: string;
+  password?: string;
+  access_cert?: string;
+  access_key?: string;
+}
+
+interface Service {
+  service_type?: string;
+  state?: string;
+  service_uri?: string | null;
+  service_uri_params?: Record<string, unknown>;
+  users?: ServiceUser[];
+}
+
+function toConnectionUser(user: ServiceUser): ServiceUser {
+  return {
+    ...(user.username ? { username: user.username } : {}),
+    ...(user.password ? { password: user.password } : {}),
+    ...(user.access_cert ? { access_cert: user.access_cert } : {}),
+    ...(user.access_key ? { access_key: user.access_key } : {}),
+  };
+}
+
+export function createConnectionInfoTool(client: AivenClient): ToolDefinition[] {
+  return [
+    {
+      name: 'aiven_service_connection_info',
+      category: ServiceCategory.Core,
+      definition: {
+        title: 'Get Service Connection Info (live credentials)',
+        description: DESCRIPTION,
+        inputSchema,
+        annotations: READ_ONLY_ANNOTATIONS,
+      },
+      handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
+        try {
+          const { project, service_name } = params as z.infer<typeof inputSchema>;
+          const opts = {
+            token: context?.token,
+            mcpClient: context?.mcpClient,
+            toolName: 'aiven_service_connection_info',
+            requestId: context?.requestId,
+          };
+
+          const service = await getServiceWithSecrets<Service>(client, project, service_name, opts);
+          if (service.state !== 'RUNNING') {
+            return toolError(
+              `Service "${service_name}" is not RUNNING (state: ${service.state ?? 'unknown'}). ` +
+                'Connection info is only available for a running service.'
+            );
+          }
+
+          const caCert = await getProjectCaCert(client, project, context?.token);
+
+          const connectionInfo = {
+            service_type: service.service_type,
+            ...(service.service_uri ? { service_uri: service.service_uri } : {}),
+            ...(service.service_uri_params ? { service_uri_params: service.service_uri_params } : {}),
+            ...(service.users ? { users: service.users.map(toConnectionUser) } : {}),
+            ca_cert: caCert,
+            tls: { required: true, verify_with: 'ca_cert' },
+          };
+
+          return toolSuccess(wrapUntrustedResponse(connectionInfo));
+        } catch (err) {
+          return toolError(errorMessage(err));
+        }
+      },
+    },
+  ];
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -96,7 +96,6 @@ function deriveAnnotations(
 
 function loadManifests(): ManifestEntry[] {
   const manifestDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'manifests');
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- trusted internal path
   const files = fs
     .readdirSync(manifestDir)
     .filter((f) => f.endsWith('.yaml'))

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -117,7 +117,7 @@ export function bearerOrIpKey(req: Request): string {
   return clientIpKey(req);
 }
 
-const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only', 'services_scope']);
+const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only', 'services_scope', 'allow_secrets']);
 
 export function parseMcpQueryParams(
   query: Record<string, unknown>,
@@ -155,7 +155,19 @@ export function parseMcpQueryParams(
     return { error: `Invalid value for services_scope: ${parsed.error}` };
   }
 
-  return { options: { readOnly, categories: parsed.categories } };
+  const rawAllowSecrets = query['allow_secrets'];
+
+  if (Array.isArray(rawAllowSecrets)) {
+    return { error: 'Duplicate query parameter: allow_secrets' };
+  }
+
+  if (rawAllowSecrets !== undefined && rawAllowSecrets !== 'true' && rawAllowSecrets !== 'false') {
+    return { error: `Invalid value for allow_secrets: must be "true" or "false"` };
+  }
+
+  const allowSecrets = rawAllowSecrets === 'true';
+
+  return { options: { readOnly, categories: parsed.categories, allowSecrets } };
 }
 
 export function startHttpServer(

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface AivenConfig {
 export interface McpRequestOptions {
   readonly readOnly: boolean;
   readonly categories: ReadonlySet<ServiceCategory> | undefined;
+  readonly allowSecrets: boolean;
 }
 
 export type McpServerFactory = (options: McpRequestOptions) => import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;

--- a/tests/runtime/connection-info.test.ts
+++ b/tests/runtime/connection-info.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createConnectionInfoTool } from '../../src/tools/connection-info.js';
+import type { AivenClient } from '../../src/client.js';
+import type { ToolResult } from '../../src/types.js';
+
+function parseResponse(result: ToolResult): Record<string, unknown> {
+  const content = result.content as Array<{ type: string; text: string }>;
+  const text = content[0].text;
+  const wrapped = text.match(/<untrusted-aiven-response-[^>]+>\n([\s\S]*?)\n<\/untrusted-aiven-response/);
+  const json = wrapped ? wrapped[1] : text;
+  return JSON.parse(json) as Record<string, unknown>;
+}
+
+function isError(result: ToolResult): boolean {
+  return result.isError === true;
+}
+
+interface MockServiceOptions {
+  state?: string;
+  service_type?: string;
+  service_uri?: string | null;
+  service_uri_params?: Record<string, unknown>;
+  users?: unknown[];
+  extra?: Record<string, unknown>;
+}
+
+function createMockClient(service: MockServiceOptions): { client: AivenClient; get: ReturnType<typeof vi.fn> } {
+  const get = vi.fn().mockImplementation((path: string) => {
+    if (path.endsWith('/kms/ca')) {
+      return Promise.resolve({ certificate: '-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----' });
+    }
+    return Promise.resolve({
+      service: {
+        state: service.state ?? 'RUNNING',
+        service_type: service.service_type ?? 'pg',
+        service_uri: service.service_uri,
+        service_uri_params: service.service_uri_params,
+        users: service.users,
+        ...service.extra,
+      },
+    });
+  });
+  const client = { get, post: get, put: get, delete: get, patch: get, request: get } as unknown as AivenClient;
+  return { client, get };
+}
+
+describe('aiven_service_connection_info', () => {
+  it('requests the service with include_secrets=true', async () => {
+    const { client, get } = createMockClient({
+      service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p', dbname: 'defaultdb' },
+    });
+    const [tool] = createConnectionInfoTool(client);
+    await tool.handler({ project: 'proj', service_name: 'pg-1' });
+
+    const serviceCall = get.mock.calls.find(([path]) => String(path).includes('/service/pg-1'));
+    expect(serviceCall).toBeDefined();
+    expect(serviceCall?.[1]).toMatchObject({ query: { include_secrets: true } });
+  });
+
+  it('returns PostgreSQL connection params and CA cert', async () => {
+    const { client } = createMockClient({
+      service_type: 'pg',
+      service_uri: 'postgres://u:p@h:5432/defaultdb',
+      service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p', dbname: 'defaultdb' },
+    });
+    const [tool] = createConnectionInfoTool(client);
+    const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'pg-1' }));
+
+    expect(parsed['service_type']).toBe('pg');
+    expect(parsed['service_uri']).toBe('postgres://u:p@h:5432/defaultdb');
+    expect(parsed['service_uri_params']).toMatchObject({ host: 'h', password: 'p' });
+    expect(parsed['ca_cert']).toContain('BEGIN CERTIFICATE');
+    expect(parsed['tls']).toEqual({ required: true, verify_with: 'ca_cert' });
+  });
+
+  it('returns Kafka mTLS cert and key from the users container', async () => {
+    const { client } = createMockClient({
+      service_type: 'kafka',
+      service_uri: 'kafka-1.aivencloud.com:12345',
+      users: [
+        {
+          username: 'avnadmin',
+          access_cert: '-----BEGIN CERTIFICATE-----\nclient\n-----END CERTIFICATE-----',
+          access_key: '-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----',
+        },
+      ],
+    });
+    const [tool] = createConnectionInfoTool(client);
+    const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'kafka-1' }));
+
+    expect(parsed['service_type']).toBe('kafka');
+    expect(parsed['service_uri']).toBe('kafka-1.aivencloud.com:12345');
+    const users = parsed['users'] as Array<Record<string, string>>;
+    expect(users[0]['access_cert']).toContain('BEGIN CERTIFICATE');
+    expect(users[0]['access_key']).toContain('BEGIN PRIVATE KEY');
+    expect(parsed['ca_cert']).toContain('BEGIN CERTIFICATE');
+  });
+
+  it('does not leak unrelated service fields (only allowlisted containers)', async () => {
+    const { client } = createMockClient({
+      service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p' },
+      extra: {
+        backups: [{ backup_name: 'b1' }],
+        service_integrations: [{ integration_type: 'x' }],
+        node_states: [{ name: 'node-1' }],
+        connection_info: { extra: 'x' },
+        components: [{ component: 'pg' }],
+      },
+    });
+    const [tool] = createConnectionInfoTool(client);
+    const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'pg-1' }));
+
+    expect(parsed['backups']).toBeUndefined();
+    expect(parsed['service_integrations']).toBeUndefined();
+    expect(parsed['node_states']).toBeUndefined();
+    expect(parsed['connection_info']).toBeUndefined();
+    expect(parsed['components']).toBeUndefined();
+  });
+
+  it('trims user objects to connection fields only', async () => {
+    const { client } = createMockClient({
+      service_type: 'kafka',
+      users: [
+        {
+          username: 'avnadmin',
+          password: 'pw',
+          access_cert: 'cert',
+          access_key: 'key',
+          access_control: { redis_acl_keys: ['*'] },
+          authentication: 'caching_sha2_password',
+          password_updated_time: '2026-01-01T00:00:00Z',
+          type: 'primary',
+        } as Record<string, unknown>,
+      ],
+    });
+    const [tool] = createConnectionInfoTool(client);
+    const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'kafka-1' }));
+
+    const user = (parsed['users'] as Array<Record<string, unknown>>)[0];
+    expect(Object.keys(user).sort()).toEqual(['access_cert', 'access_key', 'password', 'username']);
+    expect(user['access_control']).toBeUndefined();
+    expect(user['password_updated_time']).toBeUndefined();
+  });
+
+  it('errors when the service is not RUNNING', async () => {
+    const { client } = createMockClient({ state: 'REBUILDING' });
+    const [tool] = createConnectionInfoTool(client);
+    const result = await tool.handler({ project: 'proj', service_name: 'pg-1' });
+
+    expect(isError(result)).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain('REBUILDING');
+  });
+});

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -25,17 +25,17 @@ describe('parseMcpQueryParams', () => {
   describe('valid inputs', () => {
     it('returns readOnly=false and undefined categories when no query params', () => {
       const result = parseMcpQueryParams({}, false);
-      expect(result).toEqual({ options: { readOnly: false, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: false, categories: undefined, allowSecrets: false } });
     });
 
     it('returns readOnly=true when read_only=true', () => {
       const result = parseMcpQueryParams({ read_only: 'true' }, false);
-      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined, allowSecrets: false } });
     });
 
     it('returns readOnly=false when read_only=false', () => {
       const result = parseMcpQueryParams({ read_only: 'false' }, false);
-      expect(result).toEqual({ options: { readOnly: false, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: false, categories: undefined, allowSecrets: false } });
     });
 
   });
@@ -43,17 +43,17 @@ describe('parseMcpQueryParams', () => {
   describe('server-level enforcement (env var)', () => {
     it('cannot override server readOnly=true with read_only=false', () => {
       const result = parseMcpQueryParams({ read_only: 'false' }, true);
-      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined, allowSecrets: false } });
     });
 
     it('server readOnly=true with no query param stays true', () => {
       const result = parseMcpQueryParams({}, true);
-      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined, allowSecrets: false } });
     });
 
     it('server readOnly=true with read_only=true stays true', () => {
       const result = parseMcpQueryParams({ read_only: 'true' }, true);
-      expect(result).toEqual({ options: { readOnly: true, categories: undefined } });
+      expect(result).toEqual({ options: { readOnly: true, categories: undefined, allowSecrets: false } });
     });
   });
 
@@ -89,6 +89,43 @@ describe('parseMcpQueryParams', () => {
     });
   });
 
+  describe('allow_secrets', () => {
+    it('defaults allowSecrets to false when absent', () => {
+      const result = parseMcpQueryParams({}, false);
+      expect(result).toMatchObject({ options: { allowSecrets: false } });
+    });
+
+    it('returns allowSecrets=true when allow_secrets=true', () => {
+      const result = parseMcpQueryParams({ allow_secrets: 'true' }, false);
+      expect(result).toMatchObject({ options: { allowSecrets: true } });
+    });
+
+    it('returns allowSecrets=false when allow_secrets=false', () => {
+      const result = parseMcpQueryParams({ allow_secrets: 'false' }, false);
+      expect(result).toMatchObject({ options: { allowSecrets: false } });
+    });
+
+    it('is independent of server read-only enforcement (no server-side enable)', () => {
+      const result = parseMcpQueryParams({}, true);
+      expect(result).toMatchObject({ options: { allowSecrets: false } });
+    });
+
+    it('rejects array values (duplicate param injection)', () => {
+      const result = parseMcpQueryParams({ allow_secrets: ['true', 'false'] }, false);
+      expect(result).toEqual({ error: 'Duplicate query parameter: allow_secrets' });
+    });
+
+    it('rejects invalid value "1"', () => {
+      const result = parseMcpQueryParams({ allow_secrets: '1' }, false);
+      expect(result).toEqual({ error: 'Invalid value for allow_secrets: must be "true" or "false"' });
+    });
+
+    it('rejects invalid value "TRUE" (case sensitive)', () => {
+      const result = parseMcpQueryParams({ allow_secrets: 'TRUE' }, false);
+      expect(result).toEqual({ error: 'Invalid value for allow_secrets: must be "true" or "false"' });
+    });
+  });
+
   describe('services scoping', () => {
     it('parses ?services=kafka and implicitly includes core', () => {
       const result = parseMcpQueryParams({ services_scope: 'kafka' }, false);
@@ -96,6 +133,7 @@ describe('parseMcpQueryParams', () => {
         options: {
           readOnly: false,
           categories: new Set([ServiceCategory.Core, ServiceCategory.Kafka]),
+          allowSecrets: false,
         },
       });
     });
@@ -110,6 +148,7 @@ describe('parseMcpQueryParams', () => {
             ServiceCategory.Kafka,
             ServiceCategory.Pg,
           ]),
+          allowSecrets: false,
         },
       });
     });
@@ -135,8 +174,8 @@ describe('parseMcpQueryParams', () => {
       const orgA = parseMcpQueryParams({ read_only: 'true' }, false);
       const orgB = parseMcpQueryParams({}, false);
 
-      expect(orgA).toEqual({ options: { readOnly: true, categories: undefined } });
-      expect(orgB).toEqual({ options: { readOnly: false, categories: undefined } });
+      expect(orgA).toEqual({ options: { readOnly: true, categories: undefined, allowSecrets: false } });
+      expect(orgB).toEqual({ options: { readOnly: false, categories: undefined, allowSecrets: false } });
     });
   });
 });


### PR DESCRIPTION
New opt-in tool returning live PG/Kafka connection credentials (URI, params, mTLS cert/key, CA) for wiring into apps. Registered only when the connector sets ?allow_secrets=true, so it's absent from the tool list otherwise. Returns the minimum needed to connect plus a TLS-verify hint to avoid self-signed-CA setup errors. Extracts a shared getServiceWithSecrets fetch; existing connection paths unchanged.