### PR TITLE
fix: redact credential URIs embedded mid-string

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -10,7 +10,10 @@ export const REDACTED_FIELDS = new Set([
 ]);
 
 const REDACTED_KEY = /(?:^|\.)(password|token|secret|api_key|access_key|access_secret|secret_key|auth_token|private_key|client_secret|connection_string|sasl_password|keystore_password|truststore_password|.*_uri|.*_url|ca_cert|client_cert|client_key|ssl_cert|ssl_key|certificate|.*_cert|.*_key|.*_ca|.*_certificate|.*_pem)$/i;
-const SENSITIVE_VALUE = /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----|^[a-z]+:\/\/[^:]+:[^@]+@/i;
+// NOTE: the URI branch is intentionally NOT ^-anchored — secrets frequently appear
+// mid-string (e.g. "error connecting to postgres://user:pass@host/db" in log lines).
+// `\s` in the password class stops a match from greedily spanning whitespace.
+const SENSITIVE_VALUE = /-----BEGIN [A-Z ]*(?:PRIVATE KEY|CERTIFICATE)-----|[a-z]+:\/\/[^:\s]+:[^@\s]+@/i;
 
 const SCRUB_PATTERNS: { pattern: RegExp; replacement: string }[] = [
   {

--- a/tests/runtime/observability.test.ts
+++ b/tests/runtime/observability.test.ts
@@ -27,10 +27,10 @@ describe('redactReasoningField', () => {
     );
   });
 
-  it('does not redact string with embedded URI (redaction is value-level, not substring)', () => {
+  it('redacts string with embedded sensitive URI', () => {
     const input = 'connect to postgres://admin:secret@host:5432/db';
     const result = redactReasoningField(input);
-    expect(result).toBe(input);
+    expect(result).toBe(REDACTED_PLACEHOLDER);
   });
 
   it('serializes object reasoning via JSON.stringify', () => {

--- a/tests/runtime/redact.test.ts
+++ b/tests/runtime/redact.test.ts
@@ -132,6 +132,41 @@ describe('sensitive field patterns', () => {
     expect(redactSensitiveData('https://user:pass@api.example.com')).toBe(REDACTED_PLACEHOLDER);
   });
 
+  it('should redact credential URIs embedded mid-string', () => {
+    expect(
+      redactSensitiveData('error connecting to https://pg:password@host.com:1234/defaultdb')
+    ).toBe(REDACTED_PLACEHOLDER);
+    expect(
+      redactSensitiveData('failed: postgres://user:pass@host:5432/db is unreachable')
+    ).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it('should redact embedded credential URIs in object string values', () => {
+    const input = {
+      message: 'error connecting to postgres://avnadmin:AVNS_secret@pg-host:5432/defaultdb',
+      level: 'error',
+    };
+    const result = redactSensitiveData(input) as Record<string, unknown>;
+
+    expect(result['message']).toBe(REDACTED_PLACEHOLDER);
+    expect(result['level']).toBe('error');
+  });
+
+  it('should redact credential URIs in multi-line log output', () => {
+    const input = {
+      logs: [
+        { msg: 'starting service' },
+        { msg: 'connecting to kafka://user:pass@broker:9092' },
+        { msg: 'ready' },
+      ],
+    };
+    const result = redactSensitiveData(input) as { logs: { msg: string }[] };
+
+    expect(result.logs[0]?.msg).toBe('starting service');
+    expect(result.logs[1]?.msg).toBe(REDACTED_PLACEHOLDER);
+    expect(result.logs[2]?.msg).toBe('ready');
+  });
+
   it('should not redact URLs without credentials', () => {
     expect(redactSensitiveData('https://api.aiven.io/v1/project')).toBe(
       'https://api.aiven.io/v1/project'


### PR DESCRIPTION
## What

Credential URIs were only redacted when they appeared at the **start** of a string. If a secret showed up in the middle of text (like a log or error line), it leaked.

## Before vs. after

```
INPUT                                            BEFORE      AFTER
"postgres://user:pass@host/db"                   [REDACTED]  [REDACTED]
"error connecting to postgres://user:pass@host"  leaked      [REDACTED]
```

## Fix

- Removed the "must be at the start" rule from the redaction regex.
- Tightened the pattern so a match can't run across whitespace.
- Added tests for secrets embedded in strings, objects, and multi-line logs.

All 325 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)