### PR TITLE
fix: bound service_list offset and project fan-out

### DIFF
--- a/src/tools/service-search.ts
+++ b/src/tools/service-search.ts
@@ -9,7 +9,7 @@ import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
 import { DEFAULT_LIST_LIMIT } from './response-filter.js';
 
 const CONCURRENCY = 10;
-const MAX_PROJECTS_PER_CALL = 25;
+const MAX_PROJECTS_PER_CALL = CONCURRENCY;
 const MAX_OFFSET = 500;
 
 const inputSchema = z.object({

--- a/src/tools/service-search.ts
+++ b/src/tools/service-search.ts
@@ -9,6 +9,8 @@ import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
 import { DEFAULT_LIST_LIMIT } from './response-filter.js';
 
 const CONCURRENCY = 10;
+const MAX_PROJECTS_PER_CALL = 25;
+const MAX_OFFSET = 500;
 
 const inputSchema = z.object({
   project: z
@@ -35,8 +37,11 @@ const inputSchema = z.object({
     .number()
     .int()
     .min(0)
+    .max(MAX_OFFSET, {
+      message: `Pagination is intentionally bounded at offset ${MAX_OFFSET}. Instead of paging deeper, narrow the results with filters (project, service_type, state, search).`,
+    })
     .optional()
-    .describe('Number of items to skip for pagination. Use the value from `next_offset` in a previous response.'),
+    .describe(`Number of items to skip for pagination (0–${MAX_OFFSET}). Use the value from \`next_offset\` in a previous response.`),
 });
 
 interface ServiceEntry {
@@ -89,15 +94,28 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {
           const { project, service_type, state, search, limit, offset } = params as z.infer<typeof inputSchema>;
+
+          if (offset !== undefined && offset > MAX_OFFSET) {
+            return toolError(
+              `offset ${offset} exceeds the maximum of ${MAX_OFFSET}. Pagination is intentionally bounded — narrow the results with filters (project, service_type, state, search) instead of paginating deeper.`
+            );
+          }
+
           const opts = { token: context?.token, mcpClient: context?.mcpClient, toolName: 'aiven_service_list' };
 
           let projectNames: string[];
+          let totalProjects: number;
           if (project) {
             projectNames = [project];
+            totalProjects = 1;
           } else {
             const projectsRes = await client.get<{ projects: ProjectEntry[] }>('/project', opts);
-            projectNames = projectsRes.projects.map((p) => p.project_name);
+            const allProjects = projectsRes.projects.map((p) => p.project_name);
+            totalProjects = allProjects.length;
+            projectNames = allProjects.slice(0, MAX_PROJECTS_PER_CALL);
           }
+          const projectsScanned = projectNames.length;
+          const projectsSkipped = totalProjects - projectsScanned;
 
           const cap = Math.min(limit ?? DEFAULT_LIST_LIMIT, 100);
           const pageStart = offset ?? 0;
@@ -135,16 +153,39 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
           }
 
           const page = services.slice(pageStart, pageStart + cap);
-          const hasMore = pageStart + page.length < services.length || projectQueue.length > 0;
-          const nextOffset = hasMore ? pageStart + page.length : undefined;
+          const moreInScanned = pageStart + page.length < services.length || projectQueue.length > 0;
+          const hasMore = moreInScanned || projectsSkipped > 0;
+          const rawNextOffset = pageStart + page.length;
+          const nextOffset = moreInScanned && rawNextOffset <= MAX_OFFSET ? rawNextOffset : undefined;
+          const offsetCeilingReached = moreInScanned && nextOffset === undefined;
+
+          const scope = project
+            ? `project "${project}"`
+            : projectsSkipped > 0
+              ? `${projectsScanned} of ${totalProjects} accessible projects (capped at ${MAX_PROJECTS_PER_CALL} per call)`
+              : `all ${totalProjects} accessible projects`;
+
+          const hintParts: string[] = [];
+          if (projectsSkipped > 0) {
+            hintParts.push(`${projectsSkipped} project(s) were NOT searched because this call scans at most ${MAX_PROJECTS_PER_CALL}. To reach them, pass a specific \`project\`.`);
+          }
+          if (offsetCeilingReached) {
+            hintParts.push(`More services exist but offset is capped at ${MAX_OFFSET}, so they are not reachable by paginating further.`);
+          } else if (moreInScanned) {
+            hintParts.push(`More matching services exist — fetch the next page with \`offset: ${nextOffset}\`.`);
+          }
+          hintParts.push('Narrow with filters (project, service_type, state, search) rather than increasing the limit or auto-paginating.');
 
           return toolSuccess(wrapUntrustedResponse({
+            summary: `Showing ${page.length} service(s) from ${scope}.`,
             showing: page.length,
+            searched_projects: projectsScanned,
+            total_projects: totalProjects,
             ...(offset !== undefined && offset > 0 && { offset }),
             ...(nextOffset !== undefined && { next_offset: nextOffset }),
             services: page,
             ...(errors.length > 0 && { errors }),
-            ...(hasMore && { hint: 'More services exist. Ask the user what they are looking for, or narrow with filters (project, service_type, state, search). Do NOT increase the limit or auto-paginate.' }),
+            ...(hasMore && { hint: hintParts.join(' ') }),
           }));
         } catch (err) {
           return toolError(errorMessage(err));

--- a/tests/runtime/service-search.test.ts
+++ b/tests/runtime/service-search.test.ts
@@ -4,12 +4,20 @@ import type { AivenClient } from '../../src/client.js';
 import type { ToolResult } from '../../src/types.js';
 
 interface ParsedResponse {
+  summary?: string;
   showing: number;
+  searched_projects?: number;
+  total_projects?: number;
   offset?: number;
   next_offset?: number;
   hint?: string;
   services: Array<{ project: string; service_name: string; service_type: string; state: string }>;
   errors?: Array<{ project: string; error: string }>;
+}
+
+function parseError(result: ToolResult): string {
+  const content = result.content as Array<{ type: string; text: string }>;
+  return content[0].text;
 }
 
 function parseResponse(result: ToolResult): ParsedResponse {
@@ -109,7 +117,7 @@ describe('service-search', () => {
     expect(parsed.showing).toBe(3);
     expect(parsed.services).toHaveLength(3);
     expect(parsed.next_offset).toBe(3);
-    expect(parsed.hint).toContain('More services exist');
+    expect(parsed.hint).toContain('More matching services exist');
   });
 
   it('stops fetching projects early when limit is reached', async () => {
@@ -123,8 +131,7 @@ describe('service-search', () => {
     const result = await tool.handler({ limit: 3 });
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(3);
-    expect(parsed.hint).toContain('More services exist');
-    // Should not have fetched all 20 projects (concurrency=10, so at most 1 batch of /service calls)
+    expect(parsed.hint).toContain('More matching services exist');
     const getCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
     expect(getCalls.length).toBeLessThan(20);
   });
@@ -164,6 +171,63 @@ describe('service-search', () => {
     expect(parsed.services.map((s) => s.service_name)).toEqual(['my-kafka', 'my-pg']);
   });
 
+  it('rejects an offset above the maximum without any upstream calls', async () => {
+    const client = createMockClient(['proj-a'], { 'proj-a': makeServices('proj-a', 3) });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', offset: 999999 });
+    expect(result.isError).toBe(true);
+    expect(parseError(result)).toContain('exceeds the maximum');
+    expect(vi.mocked(client.get)).not.toHaveBeenCalled();
+  });
+
+  it('bounds the fan-out to at most 25 projects per call', async () => {
+    const projects = Array.from({ length: 40 }, (_, idx) => `proj-${idx}`);
+    const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
+    for (const p of projects) servicesByProject[p] = makeServices(p, 1);
+    const client = createMockClient(projects, servicesByProject);
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ limit: 100 });
+    const parsed = parseResponse(result);
+
+    expect(parsed.searched_projects).toBe(25);
+    expect(parsed.total_projects).toBe(40);
+    const serviceCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
+    expect(serviceCalls.length).toBeLessThanOrEqual(25);
+    expect(parsed.hint).toContain('15 project(s) were NOT searched');
+    expect(parsed.summary).toContain('25 of 40 accessible projects');
+  });
+
+  it('accepts an offset exactly at the maximum', async () => {
+    const client = createMockClient(['proj-a'], { 'proj-a': makeServices('proj-a', 600) });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', limit: 50, offset: 500 });
+    expect(result.isError).toBeFalsy();
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(50);
+    expect(parsed.services[0].service_name).toBe('proj-a-svc-500');
+  });
+
+  it('does not emit a next_offset beyond the offset ceiling', async () => {
+    const client = createMockClient(['proj-a'], { 'proj-a': makeServices('proj-a', 1000) });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a', limit: 100, offset: 500 });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(100);
+    expect(parsed.next_offset).toBeUndefined();
+    expect(parsed.hint).toContain('not reachable by paginating further');
+  });
+
+  it('summary states the scope when scanning all projects', async () => {
+    const client = createMockClient(['proj-a', 'proj-b'], {
+      'proj-a': makeServices('proj-a', 1),
+      'proj-b': makeServices('proj-b', 1),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const parsed = parseResponse(await tool.handler({}));
+    expect(parsed.summary).toContain('all 2 accessible projects');
+    expect(parsed.total_projects).toBe(2);
+  });
+
   it('returns default limit when no limit specified', async () => {
     const client = createMockClient(['proj-a'], {
       'proj-a': makeServices('proj-a', 20),
@@ -173,6 +237,6 @@ describe('service-search', () => {
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(15);
     expect(parsed.next_offset).toBe(15);
-    expect(parsed.hint).toContain('More services exist');
+    expect(parsed.hint).toContain('More matching services exist');
   });
 });

--- a/tests/runtime/service-search.test.ts
+++ b/tests/runtime/service-search.test.ts
@@ -180,7 +180,7 @@ describe('service-search', () => {
     expect(vi.mocked(client.get)).not.toHaveBeenCalled();
   });
 
-  it('bounds the fan-out to at most 25 projects per call', async () => {
+  it('bounds the fan-out to at most 10 projects per call', async () => {
     const projects = Array.from({ length: 40 }, (_, idx) => `proj-${idx}`);
     const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
     for (const p of projects) servicesByProject[p] = makeServices(p, 1);
@@ -189,12 +189,12 @@ describe('service-search', () => {
     const result = await tool.handler({ limit: 100 });
     const parsed = parseResponse(result);
 
-    expect(parsed.searched_projects).toBe(25);
+    expect(parsed.searched_projects).toBe(10);
     expect(parsed.total_projects).toBe(40);
     const serviceCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
-    expect(serviceCalls.length).toBeLessThanOrEqual(25);
-    expect(parsed.hint).toContain('15 project(s) were NOT searched');
-    expect(parsed.summary).toContain('25 of 40 accessible projects');
+    expect(serviceCalls.length).toBeLessThanOrEqual(10);
+    expect(parsed.hint).toContain('30 project(s) were NOT searched');
+    expect(parsed.summary).toContain('10 of 40 accessible projects');
   });
 
   it('accepts an offset exactly at the maximum', async () => {


### PR DESCRIPTION
## Problem

`aiven_service_list` could turn **one** call into a flood of upstream `api.aiven.io` calls:

- Aiven returns the **full** service list per project (no pagination), and with no `project` we opened **every** project.
- A huge `offset` (e.g. `999999`) forced a full scan of all projects just to return an empty page.
- The "do not auto-paginate" text was only a hint — the model ignored it when asked to loop.

## Fix

- **Cap `offset` at 500** — rejected up front, so no scan happens.
- **Scan at most 10 projects per call** (aligned with the concurrency batch size, so one request = a single burst of upstream calls).
- **Clearer response** — says what was searched, what's shown, what was skipped, and only offers a next page when it's actually callable.

## Result

| | Before | After |
|---|---|---|
| Projects opened per call | all of them | ≤ 10 |
| `offset: 999999` | full scan | rejected instantly |
| Auto-paginate loop | runs forever | stops at offset 500 |

336 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)