### PR TITLE
fix: disable connection info tool in read-only mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,12 +89,13 @@ async function main(): Promise<void> {
     }
 
     if (options.allowSecrets) {
-      tools = [...tools, ...createConnectionInfoTool(client)];
+      tools = [...tools, ...createConnectionInfoTool(client, options.readOnly)];
     }
 
     const instructions: string[] = [];
     if (options.readOnly) instructions.push(readOnlyInstructions(transport));
-    if (transport === 'http') instructions.push(connectionInfoInstructions(options.allowSecrets));
+    if (transport === 'http')
+      instructions.push(connectionInfoInstructions(options.allowSecrets, options.readOnly));
 
     const serverOptions =
       instructions.length > 0 ? ([{ instructions: instructions.join(' ') }] as const) : ([] as const);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -12,7 +12,14 @@ export function readOnlyInstructions(transport: 'stdio' | 'http'): string {
   );
 }
 
-export function connectionInfoInstructions(allowSecrets: boolean): string {
+export function connectionInfoInstructions(allowSecrets: boolean, readOnly: boolean): string {
+  if (allowSecrets && readOnly) {
+    return (
+      'Connection info is redacted as `[REDACTED]`. `allow_secrets=true` was requested but is ' +
+      'disabled because the server is in read-only mode — live credentials would let you bypass ' +
+      'read-only restrictions. To retrieve connection info, reconnect without `read_only=true`.'
+    );
+  }
   return allowSecrets
     ? 'Connection info is redacted as `[REDACTED]` in all tools except ' +
         '`aiven_service_connection_info` — use that tool to get live credentials.'

--- a/src/tools/connection-info.ts
+++ b/src/tools/connection-info.ts
@@ -47,7 +47,7 @@ function toConnectionUser(user: ServiceUser): ServiceUser {
   };
 }
 
-export function createConnectionInfoTool(client: AivenClient): ToolDefinition[] {
+export function createConnectionInfoTool(client: AivenClient, readOnly: boolean): ToolDefinition[] {
   return [
     {
       name: 'aiven_service_connection_info',
@@ -60,6 +60,13 @@ export function createConnectionInfoTool(client: AivenClient): ToolDefinition[] 
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {
+          if (readOnly) {
+            return toolError(
+              'Disabled while read_only is active. Connection info grants live credentials ' +
+                'that would bypass read-only restrictions. Disable read_only to retrieve connection info.'
+            );
+          }
+
           const { project, service_name } = params as z.infer<typeof inputSchema>;
           const opts = {
             token: context?.token,

--- a/tests/runtime/connection-info.test.ts
+++ b/tests/runtime/connection-info.test.ts
@@ -49,7 +49,7 @@ describe('aiven_service_connection_info', () => {
     const { client, get } = createMockClient({
       service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p', dbname: 'defaultdb' },
     });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     await tool.handler({ project: 'proj', service_name: 'pg-1' });
 
     const serviceCall = get.mock.calls.find(([path]) => String(path).includes('/service/pg-1'));
@@ -63,7 +63,7 @@ describe('aiven_service_connection_info', () => {
       service_uri: 'postgres://u:p@h:5432/defaultdb',
       service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p', dbname: 'defaultdb' },
     });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'pg-1' }));
 
     expect(parsed['service_type']).toBe('pg');
@@ -85,7 +85,7 @@ describe('aiven_service_connection_info', () => {
         },
       ],
     });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'kafka-1' }));
 
     expect(parsed['service_type']).toBe('kafka');
@@ -107,7 +107,7 @@ describe('aiven_service_connection_info', () => {
         components: [{ component: 'pg' }],
       },
     });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'pg-1' }));
 
     expect(parsed['backups']).toBeUndefined();
@@ -133,7 +133,7 @@ describe('aiven_service_connection_info', () => {
         } as Record<string, unknown>,
       ],
     });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     const parsed = parseResponse(await tool.handler({ project: 'proj', service_name: 'kafka-1' }));
 
     const user = (parsed['users'] as Array<Record<string, unknown>>)[0];
@@ -142,9 +142,22 @@ describe('aiven_service_connection_info', () => {
     expect(user['password_updated_time']).toBeUndefined();
   });
 
+  it('errors without fetching the service when read_only is active', async () => {
+    const { client, get } = createMockClient({
+      service_uri_params: { host: 'h', port: '5432', user: 'u', password: 'p' },
+    });
+    const [tool] = createConnectionInfoTool(client, true);
+    const result = await tool.handler({ project: 'proj', service_name: 'pg-1' });
+
+    expect(isError(result)).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain('read_only');
+    expect(get).not.toHaveBeenCalled();
+  });
+
   it('errors when the service is not RUNNING', async () => {
     const { client } = createMockClient({ state: 'REBUILDING' });
-    const [tool] = createConnectionInfoTool(client);
+    const [tool] = createConnectionInfoTool(client, false);
     const result = await tool.handler({ project: 'proj', service_name: 'pg-1' });
 
     expect(isError(result)).toBe(true);


### PR DESCRIPTION
## Summary

`aiven_service_connection_info` returns live credentials (passwords, connection URIs, mTLS certs). In read-only mode these credentials would let a caller bypass the read-only restrictions entirely, so the tool should not hand them out.

This change disables the tool when `read_only` is active:

- The handler errors **before** fetching the service when `read_only` is set.
- HTTP server instructions now explain that `allow_secrets` is disabled in read-only mode and how to reconnect without it.
- `createConnectionInfoTool` and `connectionInfoInstructions` take a `readOnly` flag, wired through from `index.ts`.

## Tests

- Added a test asserting the tool errors (without fetching the service) when read-only is active.
- Existing connection-info tests updated for the new signature; all 7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)