### PR TITLE
fix: bound aiven_service_list fan-out and drop broken pagination

### DIFF
--- a/src/tools/service-search.ts
+++ b/src/tools/service-search.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { z } from 'zod';
 import type { AivenClient } from '../client.js';
 import type { ToolDefinition, ToolResult, HandlerContext } from '../types.js';
@@ -9,6 +10,23 @@ import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
 import { DEFAULT_LIST_LIMIT } from './response-filter.js';
 
 const CONCURRENCY = 10;
+export const MAX_LIMIT = 100;
+export const MAX_PROJECTS_PER_SCAN = 25;
+export const MAX_PROJECT_CALLS_PER_MIN = 50;
+const RATE_WINDOW_MS = 60_000;
+
+function createProjectCallLimiter(): (token: string | undefined) => boolean {
+  const callTimes = new Map<string, number[]>();
+  return (token) => {
+    const key = token ? createHash('sha256').update(token).digest('hex') : '__stdio__';
+    const now = Date.now();
+    const recent = (callTimes.get(key) ?? []).filter((t) => t > now - RATE_WINDOW_MS);
+    callTimes.set(key, recent);
+    if (recent.length >= MAX_PROJECT_CALLS_PER_MIN) return true;
+    recent.push(now);
+    return false;
+  };
+}
 
 const TOOL_NAME = 'aiven_service_list';
 
@@ -32,13 +50,7 @@ const inputSchema = z.object({
   limit: z
     .number()
     .optional()
-    .describe(`Max results to return. Defaults to ${DEFAULT_LIST_LIMIT}. Do NOT set this unless the user explicitly asked for a specific number of results.`),
-  offset: z
-    .number()
-    .int()
-    .min(0)
-    .optional()
-    .describe('Number of items to skip for pagination. Use the value from `next_offset` in a previous response.'),
+    .describe(`Max results to return. With a single \`project\`, all matching services are returned by default. Across all projects, results default to ${DEFAULT_LIST_LIMIT} and are capped at ${MAX_LIMIT}, and only the first ${MAX_PROJECTS_PER_SCAN} projects are scanned; if more match, the response reports the totals — relay those and ask the user to narrow by project or service type.`),
 });
 
 interface ServiceEntry {
@@ -77,7 +89,17 @@ interface ProjectError {
   error: string;
 }
 
+function tally(items: ServiceResult[], key: (s: ServiceResult) => string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const item of items) {
+    const k = key(item);
+    counts[k] = (counts[k] ?? 0) + 1;
+  }
+  return counts;
+}
+
 export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
+  const tooManyProjectCalls = createProjectCallLimiter();
   return [
     {
       name: TOOL_NAME,
@@ -90,28 +112,32 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
       },
       handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
         try {
-          const { project, service_type, state, search, limit, offset } = params as z.infer<typeof inputSchema>;
+          const { project, service_type, state, search, limit } = params as z.infer<typeof inputSchema>;
           const opts = { token: context?.token, mcpClient: context?.mcpClient, toolName: 'aiven_service_list' };
 
-          let projectNames: string[];
-          if (project) {
-            projectNames = [project];
-          } else {
-            const projectsRes = await client.get<{ projects: ProjectEntry[] }>('/project', opts);
-            projectNames = projectsRes.projects.map((p) => p.project_name);
+          if (project && tooManyProjectCalls(context?.token)) {
+            return toolSuccess(wrapUntrustedResponse({
+              error: `Too many per-project queries (limit ${MAX_PROJECT_CALLS_PER_MIN}/min). This looks like an attempt to enumerate every project one by one. Stop and ask the user what they are looking for, then narrow by service_type, state, or search.`,
+            }));
           }
 
-          const cap = Math.min(limit ?? DEFAULT_LIST_LIMIT, 100);
-          const pageStart = offset ?? 0;
+          const allProjects = project
+            ? [project]
+            : (await client.get<{ projects: ProjectEntry[] }>('/project', opts)).projects.map((p) => p.project_name);
+          const totalProjects = allProjects.length;
+          const projectNames = allProjects.slice(0, MAX_PROJECTS_PER_SCAN);
+
+          const cap = project
+            ? limit
+            : Math.min(limit ?? DEFAULT_LIST_LIMIT, MAX_LIMIT);
           const services: ServiceResult[] = [];
           const errors: ProjectError[] = [];
           const typeFilter = service_type?.toLowerCase();
           const stateFilter = state?.toLowerCase();
           const searchNeedle = search?.toLowerCase();
 
-          const needed = pageStart + cap;
           const projectQueue = [...projectNames];
-          while (projectQueue.length > 0 && services.length < needed) {
+          while (projectQueue.length > 0) {
             const batch = projectQueue.splice(0, CONCURRENCY);
             const batchResults = await Promise.all(batch.map(async (proj) => {
               try {
@@ -136,17 +162,28 @@ export function createServiceSearchTool(client: AivenClient): ToolDefinition[] {
             }
           }
 
-          const page = services.slice(pageStart, pageStart + cap);
-          const hasMore = pageStart + page.length < services.length || projectQueue.length > 0;
-          const nextOffset = hasMore ? pageStart + page.length : undefined;
+          const page = cap === undefined ? services : services.slice(0, cap);
+          const rowsTruncated = page.length < services.length;
+          const projectsTruncated = totalProjects > projectNames.length;
+
+          const summary = (rowsTruncated || projectsTruncated)
+            ? {
+                returned: page.length,
+                matched: services.length,
+                by_type: tally(services, (s) => s.service_type),
+                by_state: tally(services, (s) => s.state),
+                ...(projectsTruncated && { projects_scanned: projectNames.length, projects_total: totalProjects }),
+                next_step: projectsTruncated
+                  ? `Only the first ${projectNames.length} of ${totalProjects} projects were scanned. Ask the user to name a project or filter by service_type/state/search. Do NOT call this tool once per project to cover the rest.`
+                  : 'More services matched than were returned. Tell the user these totals and offer to narrow with service_type, state, or search. Do NOT call this tool once per project.',
+              }
+            : undefined;
 
           return toolSuccess(wrapUntrustedResponse({
             showing: page.length,
-            ...(offset !== undefined && offset > 0 && { offset }),
-            ...(nextOffset !== undefined && { next_offset: nextOffset }),
             services: page,
+            ...(summary && { summary }),
             ...(errors.length > 0 && { errors }),
-            ...(hasMore && { hint: 'More services exist. Ask the user what they are looking for, or narrow with filters (project, service_type, state, search). Do NOT increase the limit or auto-paginate.' }),
           }), TOOL_NAME);
         } catch (err) {
           return toolError(errorMessage(err));

--- a/tests/runtime/service-search.test.ts
+++ b/tests/runtime/service-search.test.ts
@@ -1,13 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createServiceSearchTool } from '../../src/tools/service-search.js';
+import {
+  createServiceSearchTool,
+  MAX_LIMIT,
+  MAX_PROJECTS_PER_SCAN,
+  MAX_PROJECT_CALLS_PER_MIN,
+} from '../../src/tools/service-search.js';
+import { DEFAULT_LIST_LIMIT } from '../../src/tools/response-filter.js';
 import type { AivenClient } from '../../src/client.js';
 import type { ToolResult } from '../../src/types.js';
 
 interface ParsedResponse {
   showing: number;
-  offset?: number;
-  next_offset?: number;
-  hint?: string;
+  error?: string;
+  summary?: {
+    returned: number;
+    matched: number;
+    by_type: Record<string, number>;
+    by_state: Record<string, number>;
+    projects_scanned?: number;
+    projects_total?: number;
+    next_step: string;
+  };
   services: Array<{ project: string; service_name: string; service_type: string; state: string }>;
   errors?: Array<{ project: string; error: string }>;
 }
@@ -55,7 +68,7 @@ describe('service-search', () => {
     expect(parsed.showing).toBe(3);
     expect(parsed.services).toHaveLength(3);
     expect(parsed.services[0]).toMatchObject({ project: 'proj-a', service_name: 'proj-a-svc-0' });
-    expect(parsed.hint).toBeUndefined();
+    expect(parsed.summary).toBeUndefined();
     expect(parsed.errors).toBeUndefined();
   });
 
@@ -108,25 +121,71 @@ describe('service-search', () => {
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(3);
     expect(parsed.services).toHaveLength(3);
-    expect(parsed.next_offset).toBe(3);
-    expect(parsed.hint).toContain('More services exist');
+    expect(parsed.summary?.matched).toBe(10);
+    expect(parsed.summary?.by_type).toEqual({ pg: 10 });
   });
 
-  it('stops fetching projects early when limit is reached', async () => {
-    const projects = Array.from({ length: 20 }, (_, idx) => `proj-${idx}`);
+  it('returns all services for a single named project (no cap)', async () => {
+    const client = createMockClient(['proj-a'], {
+      'proj-a': makeServices('proj-a', 150),
+    });
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ project: 'proj-a' });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(150);
+    expect(parsed.services).toHaveLength(150);
+    expect(parsed.summary).toBeUndefined();
+  });
+
+  it('caps and reports totals when scanning across all projects', async () => {
+    const projects = Array.from({ length: 3 }, (_, idx) => `proj-${idx}`);
     const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
     for (const p of projects) {
-      servicesByProject[p] = makeServices(p, 5);
+      servicesByProject[p] = makeServices(p, 60);
     }
     const client = createMockClient(projects, servicesByProject);
     const [tool] = createServiceSearchTool(client);
-    const result = await tool.handler({ limit: 3 });
+    const result = await tool.handler({ limit: 1000 });
     const parsed = parseResponse(result);
-    expect(parsed.showing).toBe(3);
-    expect(parsed.hint).toContain('More services exist');
-    // Should not have fetched all 20 projects (concurrency=10, so at most 1 batch of /service calls)
-    const getCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
-    expect(getCalls.length).toBeLessThan(20);
+    expect(parsed.showing).toBe(MAX_LIMIT);
+    expect(parsed.summary?.returned).toBe(MAX_LIMIT);
+    expect(parsed.summary?.matched).toBeGreaterThan(MAX_LIMIT);
+    expect(parsed.summary?.next_step).toContain('narrow');
+  });
+
+  it('scans up to MAX_PROJECTS_PER_SCAN projects in one cross-project call', async () => {
+    const total = MAX_PROJECTS_PER_SCAN;
+    const projects = Array.from({ length: total }, (_, idx) => `proj-${idx}`);
+    const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
+    for (const p of projects) {
+      servicesByProject[p] = makeServices(p, 1, 'kafka');
+    }
+    const client = createMockClient(projects, servicesByProject);
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({ service_type: 'pg', limit: 100 });
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(0);
+    expect(parsed.summary).toBeUndefined();
+    const serviceCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
+    expect(serviceCalls.length).toBe(total);
+  });
+
+  it('reports an exact matched total when the row cap truncates', async () => {
+    const total = MAX_PROJECTS_PER_SCAN;
+    const projects = Array.from({ length: total }, (_, idx) => `proj-${idx}`);
+    const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
+    for (const p of projects) {
+      servicesByProject[p] = makeServices(p, 10);
+    }
+    const client = createMockClient(projects, servicesByProject);
+    const [tool] = createServiceSearchTool(client);
+    const result = await tool.handler({});
+    const parsed = parseResponse(result);
+    expect(parsed.showing).toBe(DEFAULT_LIST_LIMIT);
+    expect(parsed.summary?.matched).toBe(total * 10);
+    expect(parsed.summary?.next_step).toContain('Do NOT call this tool once per project');
+    const serviceCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
+    expect(serviceCalls.length).toBe(total);
   });
 
   it('reports errors for failed projects without swallowing them', async () => {
@@ -164,15 +223,64 @@ describe('service-search', () => {
     expect(parsed.services.map((s) => s.service_name)).toEqual(['my-kafka', 'my-pg']);
   });
 
-  it('returns default limit when no limit specified', async () => {
-    const client = createMockClient(['proj-a'], {
+  it('applies the default limit for a cross-project search when no limit specified', async () => {
+    const client = createMockClient(['proj-a', 'proj-b'], {
       'proj-a': makeServices('proj-a', 20),
+      'proj-b': makeServices('proj-b', 20),
     });
     const [tool] = createServiceSearchTool(client);
-    const result = await tool.handler({ project: 'proj-a' });
+    const result = await tool.handler({});
     const parsed = parseResponse(result);
     expect(parsed.showing).toBe(15);
-    expect(parsed.next_offset).toBe(15);
-    expect(parsed.hint).toContain('More services exist');
+    expect(parsed.summary?.matched).toBe(40);
+    expect(parsed.summary?.next_step).toContain('narrow');
+  });
+
+  it('Rule 1: a cross-project scan stops at MAX_PROJECTS_PER_SCAN and reports totals', async () => {
+    const total = MAX_PROJECTS_PER_SCAN + 30;
+    const projects = Array.from({ length: total }, (_, idx) => `proj-${idx}`);
+    const servicesByProject: Record<string, Array<{ service_name: string; service_type: string; state: string }>> = {};
+    for (const p of projects) servicesByProject[p] = makeServices(p, 1);
+    const client = createMockClient(projects, servicesByProject);
+    const [tool] = createServiceSearchTool(client);
+
+    const parsed = parseResponse(await tool.handler({}));
+    expect(parsed.summary?.projects_scanned).toBe(MAX_PROJECTS_PER_SCAN);
+    expect(parsed.summary?.projects_total).toBe(total);
+    expect(parsed.summary?.next_step).toContain('Do NOT call this tool once per project');
+    const serviceCalls = vi.mocked(client.get).mock.calls.filter((c) => c[0].includes('/service'));
+    expect(serviceCalls.length).toBe(MAX_PROJECTS_PER_SCAN);
+  });
+
+  it('Rule 2: a single named project returns all its services (full list)', async () => {
+    const client = createMockClient(['proj-a'], { 'proj-a': makeServices('proj-a', 150) });
+    const [tool] = createServiceSearchTool(client);
+    const parsed = parseResponse(await tool.handler({ project: 'proj-a' }));
+    expect(parsed.showing).toBe(150);
+    expect(parsed.summary).toBeUndefined();
+  });
+
+  it('Rule 3: looping single-project calls is cut off after MAX_PROJECT_CALLS_PER_MIN', async () => {
+    const client = createMockClient(['proj-a'], { 'proj-a': makeServices('proj-a', 1) });
+    const [tool] = createServiceSearchTool(client);
+
+    for (let i = 0; i < MAX_PROJECT_CALLS_PER_MIN; i++) {
+      const parsed = parseResponse(await tool.handler({ project: 'proj-a' }, { token: 't1' }));
+      expect(parsed.error).toBeUndefined();
+    }
+    const blocked = parseResponse(await tool.handler({ project: 'proj-a' }, { token: 't1' }));
+    expect(blocked.error).toContain('Too many per-project queries');
+  });
+
+  it('Rule 3: the per-project limit does not affect cross-project scans', async () => {
+    const client = createMockClient(['proj-a', 'proj-b'], {
+      'proj-a': makeServices('proj-a', 1),
+      'proj-b': makeServices('proj-b', 1),
+    });
+    const [tool] = createServiceSearchTool(client);
+    for (let i = 0; i < MAX_PROJECT_CALLS_PER_MIN + 5; i++) {
+      const parsed = parseResponse(await tool.handler({}));
+      expect(parsed.error).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## The problem

`aiven_service_list` could hammer the API and the MCP server:

- Called **without a project**, it fanned out to **every** project the user has, making heavy upstream calls — one request could trigger hundreds.
- The `offset` parameter let callers (or an AI agent) page through everything: `offset: 999999` forced a full scan before returning empty, and looping it amplified the load.
- The only guardrail was a text hint inside the response, which the model just ignores when asked to "list everything."

## How it's solved

Three simple, mechanical limits — no advisory text:

1. **No project →** scan at most **25 projects**, return what we found plus the totals (`matched`, counts by type/state), and tell the model to narrow by project/type/state instead of fetching everything.
2. **One project →** return all its services (or a `limit` if explicitly asked).
3. **Loop guard →** a token making more than **50 single-project calls per minute** is cut off — catches an agent that loops the tool once per project to enumerate the whole account.

Also **removes the `offset` parameter** entirely: pagination over an unpaginated upstream was broken (re-scanned everything each page) and was the main amplification vector.

## Notes

- The per-token loop guard is in-memory/per-process (same as the existing pg query limiter) — a guardrail, not a global guarantee; the transport rate limiter remains the cross-cutting backstop.
- Behavior change: `offset` no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)