### PR TITLE
feat: integrate an optional google model armor security scan for inputs and outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.1",
     "express": "^5.2.1",
+    "google-auth-library": "^10.5.0",
     "express-rate-limit": "^8.3.2",
     "libpg-query": "^17.7.3",
     "openapi-fetch": "^0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       express-rate-limit:
         specifier: ^8.3.2
         version: 8.3.2(express@5.2.1)
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.7.0
       libpg-query:
         specifier: ^17.7.3
         version: 17.7.3
@@ -1043,6 +1046,12 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -1056,6 +1065,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1151,6 +1163,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1174,6 +1190,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1309,6 +1328,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1329,6 +1351,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1353,6 +1379,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
@@ -1371,6 +1401,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
@@ -1402,6 +1440,14 @@ packages:
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
+
+  google-auth-library@10.7.0:
+    resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1525,6 +1571,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1539,6 +1588,12 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1643,6 +1698,15 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -1878,6 +1942,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
@@ -2135,6 +2202,10 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3141,6 +3212,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.3.1: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -3167,6 +3242,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
 
@@ -3248,6 +3325,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
@@ -3265,6 +3344,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -3483,6 +3566,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -3494,6 +3579,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3526,6 +3616,10 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded-parse@2.1.2:
     optional: true
 
@@ -3537,6 +3631,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-east-asian-width@1.4.0: {}
 
@@ -3571,6 +3681,19 @@ snapshots:
   globals@14.0.0: {}
 
   globals@15.15.0: {}
+
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -3672,6 +3795,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -3681,6 +3808,17 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -3786,6 +3924,14 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   npm-run-path@5.3.0:
     dependencies:
@@ -4030,6 +4176,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  safe-buffer@5.2.1: {}
 
   safe-regex@2.1.1:
     dependencies:
@@ -4282,6 +4430,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,9 @@ import { VERSION, API_ORIGIN, loadHttpMcpRateLimit } from './config.js';
 import { createObservabilityContext } from './observability.js';
 import { readOnlyInstructions, connectionInfoInstructions } from './prompts.js';
 import { instrumentServer, flushAndExit } from './instrumentation/index.js';
+import { scan } from './security/model-armor.js';
+import { unwrapUntrustedResponse } from './untrusted.js';
+import { toolError } from './types.js';
 
 /** Streamable HTTP: inbound `/mcp` `User-Agent` (SDK `requestInfo.headers`). */
 function mcpClientFromRequestInfo(requestInfo: unknown): string | undefined {
@@ -65,7 +68,28 @@ function registerTools(server: McpServer, tools: readonly ToolDefinition[]): voi
           toolReasoning: obsContext.toolReasoning,
         };
 
-        return tool.handler(params, context);
+        // Scan tool input for prompt injection / jailbreak before acting on it.
+        // Skip `reasoning` (model-generated metadata) and send plain text values,
+        // not JSON — structured JSON triggers false positives in the PI filter.
+        const inputText = Object.entries(paramsObj)
+          .filter(([key]) => key !== 'reasoning')
+          .map(([, value]) => String(value))
+          .join('\n');
+        const inputBlocked = await scan(inputText);
+        if (inputBlocked) return toolError(inputBlocked);
+
+        const result = await tool.handler(params, context);
+
+        // Scan tool output so poisoned Aiven data can't inject the user's LLM.
+        // Unwrap our own untrusted-data boundary first — its warning text would
+        // otherwise trip the prompt-injection filter.
+        const outputText = result.content
+          .map((c) => (c.type === 'text' ? unwrapUntrustedResponse(c.text) : ''))
+          .join('\n');
+        const outputBlocked = await scan(outputText, 'output');
+        if (outputBlocked) return toolError(outputBlocked);
+
+        return result;
       }
     );
   }

--- a/src/security/model-armor.ts
+++ b/src/security/model-armor.ts
@@ -1,0 +1,78 @@
+import { GoogleAuth, type AuthClient } from 'google-auth-library';
+import { captureException } from '../instrumentation/index.js';
+
+/**
+ * Google Model Armor scanning for tool input/output. Fails closed.
+ *
+ * Env: MODEL_ARMOR_ENABLED ("true" to enable), MODEL_ARMOR_SA_JSON (service-account JSON),
+ *      MODEL_ARMOR_LOCATION (default "eu"), MODEL_ARMOR_TEMPLATE (default "mcp-armor"),
+ *      MODEL_ARMOR_DEBUG ("true" logs sent text + verdict).
+ */
+
+const MAX_BYTES = 4 * 1024 * 1024; // Model Armor's content cap; over this we can't scan
+const DEFAULT_LOCATION = 'eu';
+const DEFAULT_TEMPLATE = 'mcp-armor';
+
+interface SanitizeResponse {
+  sanitizationResult: { filterMatchState: string };
+}
+
+const ENDPOINTS = {
+  input: { method: 'sanitizeUserPrompt', field: 'userPromptData' },
+  output: { method: 'sanitizeModelResponse', field: 'modelResponseData' },
+} as const;
+
+let auth: GoogleAuth | null = null;
+let base = '';
+
+function init(): GoogleAuth {
+  if (auth) return auth;
+  const sa = process.env['MODEL_ARMOR_SA_JSON'];
+  if (!sa) throw new Error('MODEL_ARMOR_ENABLED is true but MODEL_ARMOR_SA_JSON is not set');
+  let credentials: { project_id?: string };
+  try {
+    credentials = JSON.parse(sa) as { project_id?: string };
+  } catch {
+    throw new Error('MODEL_ARMOR_SA_JSON is not valid JSON');
+  }
+  const loc = process.env['MODEL_ARMOR_LOCATION'] ?? DEFAULT_LOCATION;
+  const tmpl = process.env['MODEL_ARMOR_TEMPLATE'] ?? DEFAULT_TEMPLATE;
+  base = `https://modelarmor.${loc}.rep.googleapis.com/v1/projects/${credentials.project_id}/locations/${loc}/templates/${tmpl}`;
+  auth = new GoogleAuth({ credentials, scopes: ['https://www.googleapis.com/auth/cloud-platform'] });
+  return auth;
+}
+
+/** Scan text. Returns a block reason if unsafe (fails closed), or null if safe/disabled. */
+export async function scan(text: string, kind: 'input' | 'output' = 'input'): Promise<string | null> {
+  if (process.env['MODEL_ARMOR_ENABLED'] !== 'true' || text.trim() === '') return null;
+
+  const block = (reason: string): string => {
+    const message = `[Model Armor] ${kind} blocked: ${reason}`;
+    console.error(message);
+    captureException(new Error(message)); // no-op unless SENTRY_DSN is set
+    return `Request blocked by security scan (${kind})`;
+  };
+
+  if (Buffer.byteLength(text, 'utf8') > MAX_BYTES) return block('payload too large to scan (>4MB)');
+
+  try {
+    const client: AuthClient = await init().getClient();
+    const { method, field } = ENDPOINTS[kind];
+    const res = await client.request<SanitizeResponse>({
+      url: `${base}:${method}`,
+      method: 'POST',
+      data: { [field]: { text } },
+    });
+    const state = res.data.sanitizationResult.filterMatchState;
+
+    if (process.env['MODEL_ARMOR_DEBUG'] === 'true') {
+      console.error(`[Model Armor] ${kind} (${text.length} chars) → ${state}\n${text.slice(0, 2000)}`);
+    }
+
+    if (state === 'MATCH_FOUND') return block('flagged as unsafe');
+    if (state === 'NO_MATCH_FOUND' || state === 'FILTER_MATCH_STATE_UNSPECIFIED') return null;
+    return block(`unexpected response (filterMatchState=${state})`);
+  } catch (err) {
+    return block(`scan failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/src/untrusted.ts
+++ b/src/untrusted.ts
@@ -7,13 +7,27 @@ import { UNTRUSTED_DATA_WARNING } from './prompts.js';
  * as data, not as instructions. The UUID prevents payloads from forging
  * a closing tag.
  */
+const BOUNDARY_TAG = 'untrusted-aiven-response';
+
 export function wrapUntrustedResponse(data: unknown): string {
   const uuid = randomUUID();
   const body = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
   return [
     UNTRUSTED_DATA_WARNING,
-    `<untrusted-aiven-response-${uuid}>`,
+    `<${BOUNDARY_TAG}-${uuid}>`,
     body,
-    `</untrusted-aiven-response-${uuid}>`,
+    `</${BOUNDARY_TAG}-${uuid}>`,
   ].join('\n');
+}
+
+/**
+ * Strips the untrusted-data warning and boundary tags, returning just the body.
+ * Used before security-scanning output so our own wrapper isn't mistaken for
+ * an injection. Returns the input unchanged if it isn't a wrapped response.
+ */
+export function unwrapUntrustedResponse(text: string): string {
+  const match = text.match(
+    new RegExp(`<${BOUNDARY_TAG}-[^>]+>\\n([\\s\\S]*)\\n</${BOUNDARY_TAG}-[^>]+>`)
+  );
+  return match?.[1] ?? text;
 }


### PR DESCRIPTION
Adds optional Model Armor scanning to the MCP server: tool inputs are scanned for prompt injection / jailbreak before execution, and tool outputs are scanned before returning so poisoned data can't inject the user's LLM. Blocked calls return a generic "Request blocked by security scan" error.

Config (env vars): 

  - MODEL_ARMOR_ENABLED — master switch; scanning only runs when set to true (off by default, fully no-op otherwise).
  - MODEL_ARMOR_SA_JSON — GCP service-account JSON used to auth to the Model Armor API; its project_id is used to build the API URL. Required when enabled.
  - MODEL_ARMOR_LOCATION — Model Armor region (default eu).
  - MODEL_ARMOR_TEMPLATE — Model Armor template ID with the configured filters (default mcp-armor).
  - MODEL_ARMOR_DEBUG — when true, logs scanned text + verdict for troubleshooting.
