### PR TITLE
fix: allow_secrets in stdio mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ MCP_HOST=http://localhost:3000 node dist/index.js
 | `AIVEN_TOKEN` | stdio only | -- | Aiven API token ([create one here](https://console.aiven.io/profile/tokens)) |
 | `AIVEN_READ_ONLY` | No | `false` | Set to `true` to expose only read-only tools |
 | `AIVEN_SERVICES_SCOPE` | No | -- | Comma-separated scopes to expose (e.g. `kafka`, `pg,kafka`, or `all`). Valid: `all`, `core`, `pg`, `kafka`, `application`, `integrations`. `core` is always included. Omitting the var or setting `all` loads every tool. |
+| `AIVEN_ALLOW_SECRETS` | No | `false` | Set to `true` to expose the `aiven_service_connection_info` tool, which returns live credentials (passwords, connection URIs, certs) into the conversation. Disabled while `AIVEN_READ_ONLY=true`. |
 | `MCP_HOST` | No | `https://mcp.aiven.live` | Override the OAuth protected resource host |
 | `MCP_TRANSPORT` | No | `stdio` | Set to `http` to start an HTTP server instead of stdio |
 | `MCP_HTTP_RATE_LIMIT_MAX` | No | `1000` | Max requests per window on `POST /mcp` (HTTP transport). Applies independently to a per-bearer-token bucket and a per-source-IP bucket; whichever fills first returns 429. |

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,11 +95,12 @@ export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
   }
 
   const readOnly = process.env['AIVEN_READ_ONLY'] === 'true';
+  const allowSecrets = process.env['AIVEN_ALLOW_SECRETS'] === 'true';
 
   const parsed = parseScopes(process.env['AIVEN_SERVICES_SCOPE']);
   if ('error' in parsed) {
     throw new Error(`AIVEN_SERVICES_SCOPE: ${parsed.error}`);
   }
 
-  return { token, readOnly, transport, categories: parsed.categories };
+  return { token, readOnly, transport, categories: parsed.categories, allowSecrets };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,8 +94,7 @@ async function main(): Promise<void> {
 
     const instructions: string[] = [];
     if (options.readOnly) instructions.push(readOnlyInstructions(transport));
-    if (transport === 'http')
-      instructions.push(connectionInfoInstructions(options.allowSecrets, options.readOnly));
+    instructions.push(connectionInfoInstructions(options.allowSecrets, options.readOnly, transport));
 
     const serverOptions =
       instructions.length > 0 ? ([{ instructions: instructions.join(' ') }] as const) : ([] as const);
@@ -118,7 +117,11 @@ async function main(): Promise<void> {
     });
   } else {
     const server = instrumentServer(
-      createMcpServer({ readOnly: config.readOnly, categories: config.categories, allowSecrets: false })
+      createMcpServer({
+        readOnly: config.readOnly,
+        categories: config.categories,
+        allowSecrets: config.allowSecrets,
+      })
     );
     await server.connect(createStdioTransport());
     console.error('mcp-aiven: Server connected and ready');

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -12,12 +12,26 @@ export function readOnlyInstructions(transport: 'stdio' | 'http'): string {
   );
 }
 
-export function connectionInfoInstructions(allowSecrets: boolean, readOnly: boolean): string {
+export function connectionInfoInstructions(
+  allowSecrets: boolean,
+  readOnly: boolean,
+  transport: 'stdio' | 'http'
+): string {
+  const howToDisableReadOnly =
+    transport === 'http'
+      ? 'reconnect without `read_only=true`.'
+      : 'set AIVEN_READ_ONLY=false.';
+  const howToEnable =
+    transport === 'http'
+      ? 'reconfigure the connector with `allow_secrets=true`.'
+      : 'set AIVEN_ALLOW_SECRETS=true.';
+
   if (allowSecrets && readOnly) {
     return (
       'Connection info is redacted as `[REDACTED]`. `allow_secrets=true` was requested but is ' +
       'disabled because the server is in read-only mode — live credentials would let you bypass ' +
-      'read-only restrictions. To retrieve connection info, reconnect without `read_only=true`.'
+      'read-only restrictions. To retrieve connection info, ' +
+      howToDisableReadOnly
     );
   }
   return allowSecrets
@@ -25,7 +39,8 @@ export function connectionInfoInstructions(allowSecrets: boolean, readOnly: bool
         '`aiven_service_connection_info` — use that tool to get live credentials.'
     : 'Connection info is redacted as `[REDACTED]` and cannot be retrieved through ' +
         'this connector. This is expected — do not guess credentials or call tools not ' +
-        'in your tool list. To enable, reconfigure the connector with `allow_secrets=true`.';
+        'in your tool list. To enable, ' +
+        howToEnable;
 }
 
 export const TOOL_LIST_PICKER_SUFFIX =

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface AivenConfig {
   readonly readOnly: boolean;
   readonly transport: 'stdio' | 'http';
   readonly categories: ReadonlySet<ServiceCategory> | undefined;
+  readonly allowSecrets: boolean;
 }
 
 export interface McpRequestOptions {

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -77,6 +77,34 @@ describe('loadConfig', () => {
     expect(config.readOnly).toBe(false);
   });
 
+  it('should disable allowSecrets by default when AIVEN_ALLOW_SECRETS is unset', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    delete process.env['AIVEN_ALLOW_SECRETS'];
+
+    const config = loadConfig();
+
+    expect(config.allowSecrets).toBe(false);
+  });
+
+  it('should enable allowSecrets when AIVEN_ALLOW_SECRETS is "true"', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    process.env['AIVEN_ALLOW_SECRETS'] = 'true';
+
+    const config = loadConfig();
+
+    expect(config.allowSecrets).toBe(true);
+  });
+
+  it('should disable allowSecrets for non-exact values like "TRUE" or "1"', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+
+    process.env['AIVEN_ALLOW_SECRETS'] = 'TRUE';
+    expect(loadConfig().allowSecrets).toBe(false);
+
+    process.env['AIVEN_ALLOW_SECRETS'] = '1';
+    expect(loadConfig().allowSecrets).toBe(false);
+  });
+
   it('should leave categories undefined when AIVEN_SERVICES_SCOPE is unset', () => {
     process.env['AIVEN_TOKEN'] = 'test-token';
     delete process.env['AIVEN_SERVICES_SCOPE'];


### PR DESCRIPTION
## What

Adds an `AIVEN_ALLOW_SECRETS` env var so the stdio (npx) transport can expose the `aiven_service_connection_info` tool — matching the `allow_secrets=true` query param already supported on HTTP.

Previously the stdio server hardcoded `allowSecrets: false`, so npx users had no way to retrieve live connection credentials (the workaround of passing `allow_secrets=true` as an `args[]` positional silently did nothing).

## Behavior

- `AIVEN_ALLOW_SECRETS=true` → registers `aiven_service_connection_info` on stdio.
- Defaults to `false` (strict exact-match, same pattern as `AIVEN_READ_ONLY`).
- Stays disabled while `AIVEN_READ_ONLY=true` (live credentials would bypass read-only).
- Connection-info instructions are now transport-aware, so stdio users get `AIVEN_ALLOW_SECRETS` / `AIVEN_READ_ONLY` hints instead of the HTTP query-param wording.

## Usage

```json
"aiven": {
  "command": "npx",
  "args": ["-y", "mcp-aiven"],
  "env": { "AIVEN_TOKEN": "...", "AIVEN_ALLOW_SECRETS": "true" }
}
```

## Tests

Added `loadConfig` cases (default off, `"true"` on, `TRUE`/`1` rejected). Full suite passes; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)