### PR TITLE
feat: unify build logs into service logs tool via log_type param

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -161,9 +161,9 @@ tools:
     category: core
     readOnly: true
     description: |
-      Get **runtime** service log entries for any service type, including `service_type: application` (stdout/stderr of the running container). Max **500 per call**; default `limit` 100. Built-in service logs are retained for **4 days**.
+      Get service log entries for any service type. For application services, use `log_type` to fetch **build logs** (`application-build`) or **runtime logs** (`application-run`, default).
 
-      For application services, **build logs** (Docker image build output during deploy/redeploy) are separate — use `aiven_application_build_logs_get` for those.
+      Max **500 per call**; default `limit` 100. Built-in service logs are retained for **4 days**.
 
       **Local file (required when the user asks for logs):** Do **not** leave large log payloads only in the chat. Write fetched log lines to a **local file** in the workspace (create parent directories if needed). **Default:** one file per investigation, e.g. `logs/{project}-{service_name}-{YYYYMMDD-HHMMSS}.log` — create it on the first batch and **append** every later page to that same path when paginating. Format each line with timestamp and message when available (e.g. `{time} {unit} {msg}`). Use separate files (e.g. `…-page2.log`, `…-page3.log`) **only** if the user explicitly asks for split output. In your reply, give the **file path** (unchanged across pages when appending), a short summary (time range, errors, line count), and offer the next page — do **not** paste hundreds of log lines into the message.
 

--- a/src/tools/applications/handlers.ts
+++ b/src/tools/applications/handlers.ts
@@ -20,7 +20,6 @@ import {
   redeployApplicationInput,
   vcsIntegrationListInput,
   vcsIntegrationRepositoryListInput,
-  applicationBuildLogsGetInput,
   type ServiceIntegrationInput,
 } from './schemas.js';
 
@@ -496,47 +495,6 @@ Returns \`remote_repository_id\`, \`full_name\`, \`source_url\`, and \`default_b
           );
         } catch (err) {
           return toolError(errorMessage(err));
-        }
-      },
-    },
-    {
-      name: ApplicationToolName.BuildLogsGet,
-      category: ServiceCategory.Application,
-      definition: {
-        title: 'Get Application Build Logs',
-        description: `Docker build logs for an application service (git clone → image build → push). For runtime container logs use \`aiven_project_get_service_logs\`.
-
-Start with \`sort_order: "asc"\`, \`limit: 500\`; paginate via the response \`offset\` until null. If still \`BUILDING\`/\`REBUILDING\`, return what's available and note logs are partial.`,
-        inputSchema: applicationBuildLogsGetInput,
-        annotations: READ_ONLY_ANNOTATIONS,
-      },
-      handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
-        const {
-          project,
-          service_name: serviceName,
-          limit,
-          offset,
-          sort_order: sortOrder,
-        } = params as z.infer<typeof applicationBuildLogsGetInput>;
-        const opts = {
-          token: context?.token,
-          requestId: context?.requestId,
-          toolReasoning: context?.toolReasoning,
-          query: {
-            ...(limit !== undefined ? { limit } : {}),
-            ...(offset !== undefined ? { offset } : {}),
-            ...(sortOrder !== undefined ? { sort_order: sortOrder } : {}),
-          } as Record<string, string | number | boolean | undefined>,
-        };
-
-        try {
-          const result = await client.get<Record<string, unknown>>(
-            `/project/${encodeURIComponent(project)}/service/${encodeURIComponent(serviceName)}/application/build-logs`,
-            opts
-          );
-          return toolSuccess(wrapUntrustedResponse(redactSensitiveData(result)));
-        } catch (err) {
-          return toolErrorWithRequestId(errorMessage(err), context?.requestId);
         }
       },
     },

--- a/src/tools/applications/schemas.ts
+++ b/src/tools/applications/schemas.ts
@@ -291,30 +291,3 @@ export const vcsIntegrationRepositoryListInput = z
   })
   .strict();
 
-export const applicationBuildLogsGetInput = z
-  .object({
-    project: z.string().describe('Aiven project name — use aiven_project_list to get valid names'),
-    service_name: z.string().describe('Name of the application service whose build logs to fetch'),
-    limit: z
-      .number()
-      .int()
-      .min(1)
-      .max(500)
-      .optional()
-      .describe('Max log entries to return (1–500). Default: 100.'),
-    offset: z
-      .string()
-      .optional()
-      .describe(
-        'Opaque pagination cursor from the previous response `offset` field. Omit on the first call.'
-      ),
-    sort_order: z
-      .enum(['asc', 'desc'])
-      .optional()
-      .describe(
-        'Log sort order. "asc" = oldest-first (recommended for reading a full build top-to-bottom). ' +
-          '"desc" = newest-first (default). Keep the same value when paginating.'
-      ),
-    reasoning: reasoningField,
-  })
-  .strict();

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,7 +211,6 @@ export enum ApplicationToolName {
   Redeploy = 'aiven_application_redeploy',
   VcsIntegrationList = 'aiven_vcs_integration_list',
   VcsIntegrationRepositoryList = 'aiven_vcs_integration_repository_list',
-  BuildLogsGet = 'aiven_application_build_logs_get',
 }
 
 // ---------- Kafka ----------

--- a/tests/runtime/schema-limits.test.ts
+++ b/tests/runtime/schema-limits.test.ts
@@ -17,7 +17,6 @@ import {
   redeployApplicationInput,
   vcsIntegrationListInput,
   vcsIntegrationRepositoryListInput,
-  applicationBuildLogsGetInput,
 } from '../../src/tools/applications/schemas.js';
 
 const validReasoning = 'because tests';
@@ -127,52 +126,6 @@ describe('reasoning enforcement across schemas', () => {
     expect(result.success).toBe(false);
   });
 
-  it('applicationBuildLogsGetInput rejects over-limit reasoning', () => {
-    const result = applicationBuildLogsGetInput.safeParse({
-      project: 'p',
-      service_name: 's',
-      reasoning: overLimitReasoning,
-    });
-    expect(result.success).toBe(false);
-  });
-});
-
-describe('applicationBuildLogsGetInput', () => {
-  const base = { project: 'p', service_name: 's', reasoning: validReasoning };
-
-  it('accepts valid input with no optional fields', () => {
-    expect(applicationBuildLogsGetInput.safeParse(base).success).toBe(true);
-  });
-
-  it('accepts limit within bounds', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, limit: 1 }).success).toBe(true);
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, limit: 500 }).success).toBe(true);
-  });
-
-  it('rejects limit below 1', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, limit: 0 }).success).toBe(false);
-  });
-
-  it('rejects limit above 500', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, limit: 501 }).success).toBe(false);
-  });
-
-  it('accepts valid sort_order values', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, sort_order: 'asc' }).success).toBe(true);
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, sort_order: 'desc' }).success).toBe(true);
-  });
-
-  it('rejects invalid sort_order', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, sort_order: 'newest' }).success).toBe(false);
-  });
-
-  it('accepts an offset cursor string', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, offset: '2026-06-17T10:26:56.554647+00:00' }).success).toBe(true);
-  });
-
-  it('rejects unknown keys (strict mode)', () => {
-    expect(applicationBuildLogsGetInput.safeParse({ ...base, unknown_field: 'x' }).success).toBe(false);
-  });
 });
 
 describe('SQL query length enforcement', () => {


### PR DESCRIPTION
## Summary
  - Remove `aiven_application_build_logs_get` — build logs now served via `aiven_project_get_service_logs` with `log_type: "application-build"`
  - Update service logs tool description to document the new `log_type` parameter
  
 