### PR TITLE
feat: add write_allowlist to re-enable specific write tools in read-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ You can also combine with `read_only`:
 https://mcp.aiven.live/mcp?services_scope=pg&read_only=true
 ```
 
+#### Write Exceptions in Read-Only Mode (Remote)
+
+When `read_only=true`, add `?write_allowlist=` to re-enable specific write tools while keeping
+everything else read-only. Useful when you want mostly-read access but still need to allow one
+write action, for example creating Kafka topics. Combine multiple tool names with commas. Ignored
+when `read_only` is not enabled.
+
+```
+https://mcp.aiven.live/mcp?read_only=true&write_allowlist=aiven_kafka_topic_create
+```
+
 #### Marketplace Customers (Remote)
 
 If you subscribed to Aiven through a cloud marketplace, add your marketplace as a path segment so sign-in uses the correct console:
@@ -170,6 +181,7 @@ MCP_HOST=http://localhost:3000 node dist/index.js
 | `AIVEN_READ_ONLY` | No | `false` | Set to `true` to expose only read-only tools |
 | `AIVEN_SERVICES_SCOPE` | No | -- | Comma-separated scopes to expose (e.g. `kafka`, `pg,kafka`, or `all`). Valid: `all`, `core`, `pg`, `kafka`, `application`, `integrations`. `core` is always included. Omitting the var or setting `all` loads every tool. |
 | `AIVEN_ALLOW_SECRETS` | No | `false` | Set to `true` to expose the `aiven_service_connection_info` tool, which returns live credentials (passwords, connection URIs, certs) into the conversation. Disabled while `AIVEN_READ_ONLY=true`. |
+| `AIVEN_WRITE_ALLOWLIST` | No | -- | Comma-separated tool names to re-enable while `AIVEN_READ_ONLY=true` (e.g. `aiven_kafka_topic_create`). Ignored when read-only mode is not enabled. |
 | `MCP_HOST` | No | `https://mcp.aiven.live` | Override the OAuth protected resource host |
 | `MCP_TRANSPORT` | No | `stdio` | Set to `http` to start an HTTP server instead of stdio |
 | `MCP_HTTP_RATE_LIMIT_MAX` | No | `1000` | Max requests per window on `POST /mcp` (HTTP transport). Applies independently to a per-bearer-token bucket and a per-source-IP bucket; whichever fills first returns 429. |

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,17 @@ export function parseScopes(
   return { categories: set };
 }
 
+export function parseWriteAllowlist(raw: string | undefined): ReadonlySet<string> | undefined {
+  if (raw === undefined) return undefined;
+
+  const parts = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  return parts.length > 0 ? new Set(parts) : undefined;
+}
+
 export function isMaintenanceMode(): boolean {
   return process.env['MAINTENANCE_MODE'] === 'true';
 }
@@ -96,11 +107,12 @@ export function loadConfig(transport: 'stdio' | 'http' = 'stdio'): AivenConfig {
 
   const readOnly = process.env['AIVEN_READ_ONLY'] === 'true';
   const allowSecrets = process.env['AIVEN_ALLOW_SECRETS'] === 'true';
+  const writeAllowlist = parseWriteAllowlist(process.env['AIVEN_WRITE_ALLOWLIST']);
 
   const parsed = parseScopes(process.env['AIVEN_SERVICES_SCOPE']);
   if ('error' in parsed) {
     throw new Error(`AIVEN_SERVICES_SCOPE: ${parsed.error}`);
   }
 
-  return { token, readOnly, transport, categories: parsed.categories, allowSecrets };
+  return { token, readOnly, transport, categories: parsed.categories, allowSecrets, writeAllowlist };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,8 @@ async function main(): Promise<void> {
   function createMcpServer(options: McpRequestOptions): McpServer {
     let tools: readonly ToolDefinition[] = allTools;
     if (options.readOnly) {
-      tools = tools.filter((t) => t.definition.annotations.readOnlyHint);
+      const allowlist = options.writeAllowlist;
+      tools = tools.filter((t) => t.definition.annotations.readOnlyHint || allowlist?.has(t.name));
     }
     if (options.categories) {
       const allowed = options.categories;
@@ -145,6 +146,7 @@ async function main(): Promise<void> {
         readOnly: config.readOnly,
         categories: config.categories,
         allowSecrets: config.allowSecrets,
+        writeAllowlist: config.writeAllowlist,
       })
     );
     await server.connect(createStdioTransport());

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -6,7 +6,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Request, Response, NextFunction } from 'express';
-import { HOST, parseScopes, isMaintenanceMode } from './config.js';
+import { HOST, parseScopes, parseWriteAllowlist, isMaintenanceMode } from './config.js';
 import type { HttpMcpRateLimitConfig } from './config.js';
 import type { McpServerFactory, McpRequestOptions } from './types.js';
 import { isCloudflareAddress, normalizePeerIp } from './cloudflare-ips.js';
@@ -117,7 +117,12 @@ export function bearerOrIpKey(req: Request): string {
   return clientIpKey(req);
 }
 
-const ALLOWED_MCP_QUERY_PARAMS = new Set(['read_only', 'services_scope', 'allow_secrets']);
+const ALLOWED_MCP_QUERY_PARAMS = new Set([
+  'read_only',
+  'services_scope',
+  'allow_secrets',
+  'write_allowlist',
+]);
 
 export function parseMcpQueryParams(
   query: Record<string, unknown>,
@@ -167,7 +172,19 @@ export function parseMcpQueryParams(
 
   const allowSecrets = rawAllowSecrets === 'true';
 
-  return { options: { readOnly, categories: parsed.categories, allowSecrets } };
+  const rawWriteAllowlist = query['write_allowlist'];
+
+  if (Array.isArray(rawWriteAllowlist)) {
+    return { error: 'Duplicate query parameter: write_allowlist' };
+  }
+
+  if (rawWriteAllowlist !== undefined && typeof rawWriteAllowlist !== 'string') {
+    return { error: 'Invalid value for write_allowlist: must be a comma-separated string' };
+  }
+
+  const writeAllowlist = readOnly ? parseWriteAllowlist(rawWriteAllowlist) : undefined;
+
+  return { options: { readOnly, categories: parsed.categories, allowSecrets, writeAllowlist } };
 }
 
 export function startHttpServer(

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,12 +18,14 @@ export interface AivenConfig {
   readonly transport: 'stdio' | 'http';
   readonly categories: ReadonlySet<ServiceCategory> | undefined;
   readonly allowSecrets: boolean;
+  readonly writeAllowlist: ReadonlySet<string> | undefined;
 }
 
 export interface McpRequestOptions {
   readonly readOnly: boolean;
   readonly categories: ReadonlySet<ServiceCategory> | undefined;
   readonly allowSecrets: boolean;
+  readonly writeAllowlist: ReadonlySet<string> | undefined;
 }
 
 export type McpServerFactory = (options: McpRequestOptions) => import('@modelcontextprotocol/sdk/server/mcp.js').McpServer;

--- a/tests/runtime/config.test.ts
+++ b/tests/runtime/config.test.ts
@@ -4,6 +4,7 @@ import {
   loadHttpMcpRateLimit,
   isMaintenanceMode,
   parseScopes,
+  parseWriteAllowlist,
 } from '../../src/config.js';
 import { ServiceCategory } from '../../src/types.js';
 
@@ -128,6 +129,54 @@ describe('loadConfig', () => {
     process.env['AIVEN_SERVICES_SCOPE'] = 'postgres';
 
     expect(() => loadConfig()).toThrow(/AIVEN_SERVICES_SCOPE.*Unknown scope/);
+  });
+
+  it('leaves writeAllowlist undefined when AIVEN_WRITE_ALLOWLIST is unset', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    delete process.env['AIVEN_WRITE_ALLOWLIST'];
+
+    const config = loadConfig();
+
+    expect(config.writeAllowlist).toBeUndefined();
+  });
+
+  it('parses AIVEN_WRITE_ALLOWLIST into a set of tool names', () => {
+    process.env['AIVEN_TOKEN'] = 'test-token';
+    process.env['AIVEN_WRITE_ALLOWLIST'] = 'aiven_kafka_topic_create, aiven_kafka_topic_update';
+
+    const config = loadConfig();
+
+    expect(config.writeAllowlist).toEqual(
+      new Set(['aiven_kafka_topic_create', 'aiven_kafka_topic_update'])
+    );
+  });
+});
+
+describe('parseWriteAllowlist', () => {
+  it('returns undefined when input is undefined', () => {
+    expect(parseWriteAllowlist(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(parseWriteAllowlist('')).toBeUndefined();
+  });
+
+  it('parses a single tool name', () => {
+    expect(parseWriteAllowlist('aiven_kafka_topic_create')).toEqual(
+      new Set(['aiven_kafka_topic_create'])
+    );
+  });
+
+  it('parses comma-separated tool names and trims whitespace', () => {
+    expect(parseWriteAllowlist(' aiven_kafka_topic_create , aiven_kafka_topic_update ')).toEqual(
+      new Set(['aiven_kafka_topic_create', 'aiven_kafka_topic_update'])
+    );
+  });
+
+  it('drops empty entries from trailing/duplicate commas', () => {
+    expect(parseWriteAllowlist('aiven_kafka_topic_create,,')).toEqual(
+      new Set(['aiven_kafka_topic_create'])
+    );
   });
 });
 

--- a/tests/runtime/transport.test.ts
+++ b/tests/runtime/transport.test.ts
@@ -169,6 +169,60 @@ describe('parseMcpQueryParams', () => {
     });
   });
 
+  describe('write_allowlist', () => {
+    it('is undefined by default', () => {
+      const result = parseMcpQueryParams({}, false);
+      expect(result).toMatchObject({ options: { writeAllowlist: undefined } });
+    });
+
+    it('is ignored when read_only is not enabled', () => {
+      const result = parseMcpQueryParams({ write_allowlist: 'aiven_kafka_topic_create' }, false);
+      expect(result).toMatchObject({ options: { readOnly: false, writeAllowlist: undefined } });
+    });
+
+    it('parses a single tool name when read_only=true', () => {
+      const result = parseMcpQueryParams(
+        { read_only: 'true', write_allowlist: 'aiven_kafka_topic_create' },
+        false
+      );
+      expect(result).toEqual({
+        options: {
+          readOnly: true,
+          categories: undefined,
+          allowSecrets: false,
+          writeAllowlist: new Set(['aiven_kafka_topic_create']),
+        },
+      });
+    });
+
+    it('parses comma-separated tool names with whitespace', () => {
+      const result = parseMcpQueryParams(
+        { read_only: 'true', write_allowlist: 'aiven_kafka_topic_create, aiven_kafka_topic_update' },
+        false
+      );
+      expect(result).toMatchObject({
+        options: {
+          writeAllowlist: new Set(['aiven_kafka_topic_create', 'aiven_kafka_topic_update']),
+        },
+      });
+    });
+
+    it('applies when server-level readOnly is enforced via env, even without ?read_only in the query', () => {
+      const result = parseMcpQueryParams({ write_allowlist: 'aiven_kafka_topic_create' }, true);
+      expect(result).toMatchObject({
+        options: { readOnly: true, writeAllowlist: new Set(['aiven_kafka_topic_create']) },
+      });
+    });
+
+    it('rejects array values (duplicate param injection)', () => {
+      const result = parseMcpQueryParams(
+        { read_only: 'true', write_allowlist: ['a', 'b'] },
+        false
+      );
+      expect(result).toEqual({ error: 'Duplicate query parameter: write_allowlist' });
+    });
+  });
+
   describe('tenant isolation', () => {
     it('produces independent results for different inputs (no shared state)', () => {
       const orgA = parseMcpQueryParams({ read_only: 'true' }, false);


### PR DESCRIPTION
## Summary
- Adds `AIVEN_WRITE_ALLOWLIST` (env) and `write_allowlist` (HTTP query param) to re-enable specific write tools while `read_only` is otherwise enforced — e.g. allow `aiven_kafka_topic_create` while keeping everything else read-only.
- New `parseWriteAllowlist` helper in `src/config.ts` parses a comma-separated tool-name list into a `Set<string>`, trimming whitespace and dropping empty entries.
- Tool filtering in `src/index.ts` now keeps a tool when it's read-only OR explicitly present in the allowlist.
- `write_allowlist` is only honored when `read_only` is actually enabled (env or query); it's a no-op otherwise, matching existing param precedence in `src/transport.ts`.
- Query param handling rejects duplicate/array values for `write_allowlist`, consistent with the other query params.
- Threaded the new field through `AivenConfig` / `McpRequestOptions` in `src/types.ts`.
- Documented the new env var and remote query param in `README.md`.

## Test plan
- [x] `parseWriteAllowlist` unit tests: undefined/empty input, single value, comma-separated with whitespace, trailing/duplicate commas.
- [x] `loadConfig` tests: unset vs. set `AIVEN_WRITE_ALLOWLIST`.
- [x] `parseMcpQueryParams` tests: default undefined, ignored when not read-only, parsed when `read_only=true` via query or server-enforced env, duplicate-param rejection.