### PR TITLE
fix: reflect write_allowlist in read-only mode instructions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ async function main(): Promise<void> {
     }
 
     const instructions: string[] = [];
-    if (options.readOnly) instructions.push(readOnlyInstructions(transport));
+    if (options.readOnly) instructions.push(readOnlyInstructions(transport, options.writeAllowlist));
     instructions.push(connectionInfoInstructions(options.allowSecrets, options.readOnly, transport));
 
     const serverOptions =

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,8 +1,23 @@
-export function readOnlyInstructions(transport: 'stdio' | 'http'): string {
+export function readOnlyInstructions(
+  transport: 'stdio' | 'http',
+  writeAllowlist?: ReadonlySet<string>
+): string {
   const howToDisable =
     transport === 'http'
       ? 'they need to reconnect without the `read_only=true` query parameter to enable write operations.'
       : 'they need to set AIVEN_READ_ONLY=false to enable write operations.';
+
+  if (writeAllowlist && writeAllowlist.size > 0) {
+    const allowed = [...writeAllowlist].sort().join(', ');
+    return (
+      'This server is running in READ-ONLY mode with a write allowlist. ' +
+      'Only read/query tools are available, EXCEPT these explicitly re-enabled write tools, ' +
+      `which you CAN use: ${allowed}. ` +
+      'Any other create, update, or delete operation is unavailable. ' +
+      'If the user asks for a change outside the allowlist, inform them that ' +
+      howToDisable
+    );
+  }
 
   return (
     'This server is running in READ-ONLY mode. Only read/query tools are available. ' +

--- a/tests/runtime/prompts.test.ts
+++ b/tests/runtime/prompts.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readOnlyInstructions } from '../../src/prompts.js';
+
+describe('readOnlyInstructions', () => {
+  describe('without a write allowlist', () => {
+    it('states no writes are possible', () => {
+      const text = readOnlyInstructions('http');
+      expect(text).toContain('READ-ONLY mode');
+      expect(text).toContain('CANNOT create, update, or delete any resources');
+    });
+
+    it('treats an empty allowlist the same as none', () => {
+      const text = readOnlyInstructions('http', new Set());
+      expect(text).toContain('CANNOT create, update, or delete any resources');
+      expect(text).not.toContain('write allowlist');
+    });
+
+    it('gives the http reconnect hint', () => {
+      const text = readOnlyInstructions('http');
+      expect(text).toContain('reconnect without the `read_only=true` query parameter');
+    });
+
+    it('gives the stdio env-var hint', () => {
+      const text = readOnlyInstructions('stdio');
+      expect(text).toContain('AIVEN_READ_ONLY=false');
+    });
+  });
+
+  describe('with a write allowlist', () => {
+    it('names the re-enabled write tools and does not claim writes are impossible', () => {
+      const text = readOnlyInstructions('http', new Set(['aiven_service_create']));
+      expect(text).toContain('write allowlist');
+      expect(text).toContain('aiven_service_create');
+      expect(text).toContain('you CAN use');
+      expect(text).not.toContain('CANNOT create, update, or delete any resources');
+    });
+
+    it('lists multiple allowlisted tools sorted for stable output', () => {
+      const text = readOnlyInstructions('http', new Set(['aiven_service_create', 'aiven_kafka_topic_create']));
+      expect(text).toContain('aiven_kafka_topic_create, aiven_service_create');
+    });
+
+    it('still explains how to fully disable read-only mode', () => {
+      const text = readOnlyInstructions('stdio', new Set(['aiven_service_create']));
+      expect(text).toContain('AIVEN_READ_ONLY=false');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a connection uses read-only mode together with a `write_allowlist` (added in #141), the allowlisted write tools *are* correctly exposed and callable (`src/index.ts:107-109`). But the read-only banner produced by `readOnlyInstructions` still stated:

> Only read/query tools are available. You CANNOT create, update, or delete any resources.

That contradiction causes clients to refuse to use the re-enabled write tools even though they're available — the model trusts the banner over its actual tool set, tells the user "I can't create anything," and only discovers the truth by inspecting the tool schema.

## Fix

`readOnlyInstructions` now accepts the optional `writeAllowlist`. When it's non-empty, it emits a banner that:
- names the explicitly re-enabled write tools ("...EXCEPT these explicitly re-enabled write tools, which you CAN use: `aiven_service_create`...")
- clarifies that only operations *outside* the allowlist are unavailable
- still explains how to fully disable read-only mode

An empty or absent allowlist keeps the original banner verbatim, so the default read-only experience is unchanged.

## Changes
- `src/prompts.ts` — `readOnlyInstructions(transport, writeAllowlist?)` with allowlist-aware branch
- `src/index.ts` — pass `options.writeAllowlist` into `readOnlyInstructions`
- `tests/runtime/prompts.test.ts` — new file: both branches, empty-set handling, sorted multi-tool output, transport-specific disable hints

## Verification
- `tsc --noEmit`: clean
- `eslint`: clean
- `vitest run`: 386 tests pass (18 files, incl. new prompts test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)