### PR TITLE
fix: enhance model armor input scanning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,12 +69,11 @@ function registerTools(server: McpServer, tools: readonly ToolDefinition[]): voi
         };
 
         // Scan tool input for prompt injection / jailbreak before acting on it.
-        // Skip `reasoning` (model-generated metadata) and send plain text values,
-        // not JSON — structured JSON triggers false positives in the PI filter.
-        const inputText = Object.entries(paramsObj)
-          .filter(([key]) => key !== 'reasoning')
-          .map(([, value]) => String(value))
-          .join('\n');
+        // Skip `reasoning` (model-generated metadata) and send the raw JSON params.
+        const scanParams = Object.fromEntries(
+          Object.entries(paramsObj).filter(([key]) => key !== 'reasoning')
+        );
+        const inputText = JSON.stringify(scanParams);
         const inputBlocked = await scan(inputText);
         if (inputBlocked) return toolError(inputBlocked);
 

--- a/tests/eval/model-armor.eval.test.ts
+++ b/tests/eval/model-armor.eval.test.ts
@@ -265,6 +265,12 @@ const FIXTURES: EvalFixture[] = [
     text: JSON.stringify({ project: 'example-project', query: INJECTION }),
     expect: 'block',
   },
+  {
+    name: 'input: jailbreak nested in object param',
+    kind: 'input',
+    text: JSON.stringify({ project: 'example-project', config: { note: INJECTION } }),
+    expect: 'block',
+  },
 ];
 
 const HAS_CREDS = Boolean(process.env['MODEL_ARMOR_SA_JSON']);


### PR DESCRIPTION
Enhancing the model armor input scanning to scan the full input, instead of just the first layer of input