### PR TITLE
fix: remove assistant-directed instructions from tool descriptions

### DIFF
--- a/src/manifests/core.yaml
+++ b/src/manifests/core.yaml
@@ -9,7 +9,7 @@ tools:
       key: projects
       fields: [project_name, default_cloud, organization_id, tags]
     description: |
-      List all Aiven projects. ALWAYS call this first to get valid `project` names — never guess project names.
+      List all Aiven projects. Returns the valid `project` names used by other tools.
       This tool returns a list of projects with the following fields:
       - project_name: The name of the project
       - default_cloud: The default cloud for the project
@@ -165,8 +165,6 @@ tools:
 
       Max **500 per call**; default `limit` 100. Built-in service logs are retained for **4 days**.
 
-      **Local file (required when the user asks for logs):** Do **not** leave large log payloads only in the chat. Write fetched log lines to a **local file** in the workspace (create parent directories if needed). **Default:** one file per investigation, e.g. `logs/{project}-{service_name}-{YYYYMMDD-HHMMSS}.log` — create it on the first batch and **append** every later page to that same path when paginating. Format each line with timestamp and message when available (e.g. `{time} {unit} {msg}`). Use separate files (e.g. `…-page2.log`, `…-page3.log`) **only** if the user explicitly asks for split output. In your reply, give the **file path** (unchanged across pages when appending), a short summary (time range, errors, line count), and offer the next page — do **not** paste hundreds of log lines into the message.
-
       **Severity filter:** Use `severity` when the user asks for a specific log level. Allowed values: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`. Omit to return all severities. Keep the same `severity` when paginating.
 
       **Sort order:** Use `sort_order: "desc"` (API default) for newest-first troubleshooting. Use `"asc"` only when the user explicitly wants oldest-first.
@@ -202,13 +200,9 @@ tools:
 
       Use `period` to control the time window: `hour`, `day`, `week`, `month`, or `year`. **Default to `day`** for general overview requests; use `hour` only when the user is investigating something that just happened, and longer windows only when explicitly asked.
 
-      **Before calling with a granular period**, warn the user if you expect a large payload and ask them to confirm. Rough point counts per host per metric: `hour` ≈ 120, `day` ≈ 1440, `week` ≈ 2016, `month` ≈ 720, `year` ≈ 1460. Multi-host services (e.g. HA Postgres) and Kafka topic-level queries multiply this. If the user asks for `day` or finer on a multi-host service, or `week`/finer on anything, say something like "this will return a lot of data points — I'll summarize it, but want to confirm before fetching?" and wait for confirmation.
+      **Response modes:** With `metrics` omitted, returns an overview: the list of available metric names plus min/avg/max/latest per series. With `metrics` set to one or more names from that list (e.g. `["cpu_usage"]`), returns the complete per-point time series for those metrics, so individual spikes are visible.
 
       For Kafka services, optionally pass `kafka_topic_name` to get topic-level metrics.
-
-      **Display format:** Render as a compact ASCII dashboard using box-drawing characters (┌─┐│└┘) and progress bars (█░). One section per metric group. For each metric series, show a one-line summary: **min / avg / max / latest** (plus units and host/node when multi-host). Do NOT echo every data point by default. Do NOT use markdown tables or bullet points. Do NOT generate scripts. Render directly as text.
-
-      **Raw data:** After the dashboard, add a short line telling the user they can ask for raw data points for any specific metric. Only dump raw series when the user explicitly asks, and only for the specific metric they named.
 
   # Not in public OpenAPI — schema is maintained here (see generator manual_schema).
   - name: aiven_service_application_metrics_get

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -59,8 +59,7 @@ export function connectionInfoInstructions(
 }
 
 export const TOOL_LIST_PICKER_SUFFIX =
-  '**Lists & picks:** When turning this tool’s output into user choices, curate **2–5** options at a time unless they explicitly ask for the full catalog. ' +
-  'In **Claude Code**, prefer `AskUserQuestion` when appropriate.';
+  'This tool may return a long list; results support filtering and pagination to narrow large catalogs.';
 
 export const UNTRUSTED_DATA_WARNING =
   'The following query results contain untrusted data from a database. ' +

--- a/src/tool-result-limit.ts
+++ b/src/tool-result-limit.ts
@@ -13,9 +13,47 @@ function trimSuffix(originalLength: number, limit: number, toolName?: string): s
   return (
     `\n\n---\n**Trimmed:** The ${toolName ?? 'tool'} response was cut because it exceeded the maximum tool output size ` +
     `(${originalLength} characters; cap ${limit} from MCP_MAX_TOOL_RESULT_CHARS). ` +
-    `Only the beginning of the payload is included—the rest was omitted. ` +
-    `If this was JSON, the tail may be incomplete. Narrow the request or raise the cap if needed.`
+    `Only the beginning of the payload is included—later entries were omitted. ` +
+    `If this was JSON, open brackets were closed so the retained prefix still parses. ` +
+    `The full data is available with a narrower request or a higher cap.`
   );
+}
+
+function sliceToLineBoundary(text: string, headLen: number): string {
+  const hard = text.slice(0, headLen);
+  const lastNewline = hard.lastIndexOf('\n');
+  return lastNewline > 0 ? hard.slice(0, lastNewline) : hard;
+}
+
+/** Upper bound on characters appended by {@link closeTruncatedJson} (closing brackets). */
+const JSON_CLOSE_RESERVE = 64;
+
+function closeTruncatedJson(text: string): string {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (const ch of text) {
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{' || ch === '[') stack.push(ch);
+    else if (ch === '}' || ch === ']') stack.pop();
+  }
+
+  if (stack.length === 0 && !inString) return text;
+
+  let out = text.trimEnd();
+  if (inString) out += '"';
+  else if (out.endsWith(',')) out = out.slice(0, -1);
+
+  for (let i = stack.length - 1; i >= 0; i--) {
+    out += stack[i] === '{' ? '}' : ']';
+  }
+  return out;
 }
 
 /**
@@ -26,12 +64,12 @@ export function applyToolResultCharCap(text: string, toolName?: string): string 
   const limit = getMaxToolResultChars();
   if (limit <= 0 || text.length <= limit) return text;
 
-  const suffix = trimSuffix(text.length, limit, toolName);
-  let headLen = limit - suffix.length;
-
+  // Prefer the descriptive notice; fall back to a minimal one when the cap is too tight for it.
+  let notice = trimSuffix(text.length, limit, toolName);
+  let headLen = limit - notice.length - JSON_CLOSE_RESERVE;
   if (headLen < 0) {
-    const minimal = `\n… [mcp-aiven: trimmed ${String(text.length)}→${String(limit)} chars]`;
-    headLen = limit - minimal.length;
+    notice = `\n… [mcp-aiven: trimmed ${String(text.length)}→${String(limit)} chars]`;
+    headLen = limit - notice.length - JSON_CLOSE_RESERVE;
     if (headLen <= 0) {
       console.error(
         'mcp-aiven: Tool result trim: cap %d too small for payload of %d chars; returning truncated notice only (tool=%s)',
@@ -39,20 +77,11 @@ export function applyToolResultCharCap(text: string, toolName?: string): string 
         text.length,
         toolName ?? 'unknown'
       );
-      return minimal.slice(0, limit);
+      return notice.slice(0, limit);
     }
-    const out = text.slice(0, headLen) + minimal;
-    console.error(
-      'mcp-aiven: Tool result trimmed: %d -> %d chars (tool=%s, MCP_MAX_TOOL_RESULT_CHARS=%d)',
-      text.length,
-      out.length,
-      toolName ?? 'unknown',
-      limit
-    );
-    return out;
   }
 
-  const out = text.slice(0, headLen) + suffix;
+  const out = closeTruncatedJson(sliceToLineBoundary(text, headLen)) + notice;
   console.error(
     'mcp-aiven: Tool result trimmed: %d -> %d chars (tool=%s, MCP_MAX_TOOL_RESULT_CHARS=%d)',
     text.length,

--- a/src/tools/api-tool.ts
+++ b/src/tools/api-tool.ts
@@ -4,7 +4,7 @@ import { toolSuccess, toolErrorWithRequestId } from '../types.js';
 import { errorMessage } from '../errors.js';
 import { redactSensitiveData } from '../security.js';
 import { wrapUntrustedResponse } from '../untrusted.js';
-import { applyResponseFilter, extendSchemaWithSearch, stripSearchParams } from './response-filter.js';
+import { applyResponseFilter, extendSchemaWithSearch, SEARCH_PARAMS } from './response-filter.js';
 
 function extractPathParams(path: string): Set<string> {
   return new Set(
@@ -80,6 +80,12 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     : config.inputSchema;
   const hasSearch = inputSchema !== config.inputSchema;
 
+  const clientOnly = new Set([
+    'reasoning',
+    ...(hasSearch ? SEARCH_PARAMS : []),
+    ...(config.clientOnlyParams ?? []),
+  ]);
+
   return {
     name: config.name,
     category: config.category,
@@ -92,13 +98,12 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
     handler: async (params, context?: HandlerContext): Promise<ToolResult> => {
       try {
         const args = params as Record<string, unknown>;
-        const apiArgs = hasSearch ? stripSearchParams(args) : args;
         const search = hasSearch ? args['search'] as string | undefined : undefined;
         const limit = hasSearch ? args['limit'] as number | undefined : undefined;
         const offset = hasSearch ? args['offset'] as number | undefined : undefined;
 
-        const argsWithoutReasoning = Object.fromEntries(
-          Object.entries(apiArgs).filter(([key]) => key !== 'reasoning')
+        const apiArgs = Object.fromEntries(
+          Object.entries(args).filter(([key]) => !clientOnly.has(key))
         );
 
         const opts: RequestOptions = {
@@ -109,14 +114,16 @@ export function createApiTool(config: ApiToolConfig, client: AivenClient): ToolD
           toolReasoning: context?.toolReasoning,
         };
 
-        const data = await executeRequest(client, config, argsWithoutReasoning, pathParams, opts);
+        const data = await executeRequest(client, config, apiArgs, pathParams, opts);
         const redacted = redactSensitiveData(data);
 
         const filtered = config.responseFilter
           ? applyResponseFilter(redacted, config.responseFilter, search, limit, offset)
           : redacted;
 
-        return toolSuccess(wrapUntrustedResponse(filtered), config.name);
+        const processed = config.postProcess ? config.postProcess(filtered, args) : filtered;
+
+        return toolSuccess(wrapUntrustedResponse(processed), config.name);
       } catch (err) {
         return toolErrorWithRequestId(errorMessage(err), context?.requestId);
       }

--- a/src/tools/kafka/descriptions.ts
+++ b/src/tools/kafka/descriptions.ts
@@ -14,8 +14,7 @@ Supports Debezium CDC connectors (PostgreSQL, MySQL), JDBC source/sink, and any 
 
 **IMPORTANT — topics must exist before the connector starts.** Aiven Kafka does not auto-create topics. Create all required topics using \`aiven_kafka_topic_create\` before or immediately after creating the connector. Topic naming depends on the connector type (e.g. Debezium uses \`{topic.prefix}.{schema}.{table}\`).
 
-**Assistant:** If you suggest enabling public access for Kafka (e.g. \`user_config.public_access\`), include this line for the user:
-- ⚠️ WARNING: This makes the Kafka service reachable from the internet.
+Note: enabling public access for Kafka (e.g. \`user_config.public_access\`) makes the Kafka service reachable from the internet.
 
 ${TOOL_LIST_PICKER_SUFFIX}`;
 

--- a/src/tools/metrics-shape.ts
+++ b/src/tools/metrics-shape.ts
@@ -1,0 +1,205 @@
+import { z } from 'zod';
+import type { ApiToolConfig } from '../types.js';
+
+/**
+ * Response shaping for `aiven_service_metrics_fetch`.
+ *
+ * The Aiven metrics API returns a DataTable per metric group:
+ *   metrics.{group}.data = { cols: [{label,type}, ...], rows: [[time, n, n], ...] }
+ * A single `hour`/`day` request over a multi-host service returns hundreds of points across
+ * ~9 groups (~100KB) — past the tool-result size cap, so the tail gets truncated and data is
+ * silently lost.
+ *
+ * Instead of truncating, the tool serves the two real intents explicitly:
+ *   - `metrics` omitted  → overview: available metric names + per-series
+ *                          min/avg/max/first/latest. Small enough to always fit (~3KB).
+ *   - `metrics` provided → the FULL, untouched per-point series for exactly those groups,
+ *                          so every spike is visible. One group ≈ 16KB — fits.
+ */
+
+const METRICS_FETCH_TOOL_NAME = 'aiven_service_metrics_fetch';
+
+/** The one client-side input param: which metric groups to return in full detail. */
+const METRICS_PARAM = 'metrics';
+
+/**
+ * Config overrides that wire the metrics shaping into the one tool that needs it.
+ * Returns an empty object for every other tool, so the registry can spread it unconditionally.
+ */
+export function metricsConfigOverrides(
+  toolName: string,
+  baseSchema: z.ZodType
+): Partial<Pick<ApiToolConfig, 'inputSchema' | 'postProcess' | 'clientOnlyParams'>> {
+  if (toolName !== METRICS_FETCH_TOOL_NAME) return {};
+  return {
+    inputSchema: extendMetricsSchema(baseSchema),
+    postProcess: shapeMetricsResponse,
+    clientOnlyParams: [METRICS_PARAM],
+  };
+}
+
+/** Add the `metrics` selector to the tool's input schema. */
+function extendMetricsSchema(baseSchema: z.ZodType): z.ZodType {
+  if (!(baseSchema instanceof z.ZodObject)) return baseSchema;
+  return baseSchema
+    .extend({
+      [METRICS_PARAM]: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Metric groups to return with full per-point detail (e.g. ["cpu_usage", "mem_usage"]). ' +
+            'When omitted, the response is an overview of all available metrics with ' +
+            'min/avg/max/latest per series; the overview lists the exact names accepted here.'
+        ),
+    })
+    .passthrough();
+}
+
+interface DataTableCol {
+  label?: string;
+}
+
+/** Shape established by {@link isMetricGroup} — `cols` and `rows` are verified arrays. */
+interface MetricGroup {
+  data: {
+    cols: DataTableCol[];
+    rows: unknown[][];
+  };
+}
+
+interface SeriesSummary {
+  series: string;
+  points: number;
+  min: number | null;
+  avg: number | null;
+  max: number | null;
+  latest: number | null;
+}
+
+function round(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}
+
+function isMetricGroup(value: unknown): value is MetricGroup {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const data = (value as { data?: { cols?: unknown; rows?: unknown } }).data;
+  return Array.isArray(data?.cols) && Array.isArray(data.rows);
+}
+
+/** Rows whose first cell is a time value (the API echoes the column defs as the first row). */
+function dataRowsOf(group: MetricGroup): unknown[][] {
+  return group.data.rows.filter((r): r is unknown[] => {
+    if (!Array.isArray(r)) return false;
+    const first: unknown = r[0];
+    return typeof first === 'string' || typeof first === 'number';
+  });
+}
+
+function summarizeGroup(group: MetricGroup): Record<string, unknown> {
+  const cols = group.data.cols;
+  const rows = dataRowsOf(group);
+
+  const series: SeriesSummary[] = [];
+  for (let i = 1; i < cols.length; i++) {
+    const values: number[] = [];
+    for (const row of rows) {
+      const v: unknown = row[i];
+      if (typeof v === 'number' && Number.isFinite(v)) values.push(v);
+    }
+    const label = cols[i]?.label ?? `series_${String(i)}`;
+    if (values.length === 0) {
+      series.push({ series: label, points: 0, min: null, avg: null, max: null, latest: null });
+      continue;
+    }
+    let min = values[0] as number;
+    let max = min;
+    let sum = 0;
+    for (const v of values) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+      sum += v;
+    }
+    series.push({
+      series: label,
+      points: values.length,
+      min: round(min),
+      avg: round(sum / values.length),
+      max: round(max),
+      latest: round(values[values.length - 1] as number),
+    });
+  }
+
+  const firstRow = rows[0];
+  const lastRow = rows[rows.length - 1];
+  const timeRange =
+    firstRow && lastRow ? [String(firstRow[0]), String(lastRow[0])] : null;
+
+  return { time_range: timeRange, series };
+}
+
+/**
+ * Shape the metrics response by the caller's requested scope. Returns the input unchanged
+ * when it is not a metrics payload, so it is safe on error responses.
+ */
+export function shapeMetricsResponse(
+  data: Record<string, unknown>,
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  const metrics = data['metrics'];
+  if (metrics === null || typeof metrics !== 'object' || Array.isArray(metrics)) return data;
+  const groups = metrics as Record<string, unknown>;
+  const names = Object.keys(groups).filter((n) => isMetricGroup(groups[n]));
+  if (names.length === 0) return data;
+
+  const rawRequested = args[METRICS_PARAM];
+  const requested = Array.isArray(rawRequested)
+    ? rawRequested.filter((v): v is string => typeof v === 'string' && v.trim() !== '')
+    : [];
+
+  // Detail mode: full untouched series for the requested groups only.
+  if (requested.length > 0) {
+    const byLowerName = new Map(names.map((n) => [n.toLowerCase(), n]));
+    const selected: Record<string, unknown> = {};
+    const matched: string[] = [];
+    const unmatched: string[] = [];
+    for (const req of requested) {
+      const name = byLowerName.get(req.trim().toLowerCase());
+      if (name === undefined) {
+        unmatched.push(req);
+      } else if (!(name in selected)) {
+        selected[name] = groups[name];
+        matched.push(name);
+      }
+    }
+
+    if (matched.length === 0) {
+      return {
+        metrics: {},
+        available_metrics: names,
+        note: `No requested metric matched. Available metrics: ${names.join(', ')}.`,
+      };
+    }
+    return {
+      metrics: selected,
+      returned_metrics: matched,
+      ...(unmatched.length > 0 && { unmatched_requested: unmatched }),
+      note:
+        'Full per-point time series for the requested metric(s). ' +
+        `Other available metrics: ${names.filter((n) => !matched.includes(n)).join(', ')}.`,
+    };
+  }
+
+  // Overview mode: per-series stats for every group. Nothing is truncated.
+  const overview: Record<string, unknown> = {};
+  for (const name of names) {
+    overview[name] = summarizeGroup(groups[name] as MetricGroup);
+  }
+  return {
+    available_metrics: names,
+    overview,
+    note:
+      'Overview: min/avg/max/latest per series, in each metric’s native unit. The full ' +
+      'per-point time series of any metric (including individual spikes) is available via the ' +
+      '`metrics` parameter, e.g. metrics: ["cpu_usage"].',
+  };
+}

--- a/src/tools/pg/descriptions.ts
+++ b/src/tools/pg/descriptions.ts
@@ -19,8 +19,7 @@ Works best with SELECT queries but also helps with INSERT/UPDATE/DELETE.
 
 export const PG_READ_DESCRIPTION = `Execute a read-only SQL query against an Aiven PostgreSQL service.
 
-**Assistant:** If you suggest enabling public DB access, include this line for the user:
-- ⚠️ WARNING: This makes the database reachable from the internet.
+Note: enabling public DB access makes the database reachable from the internet.
 
 The connection is made in read-only mode with a 30-second timeout.
 Only SELECT and other read operations are allowed. INSERT, UPDATE, DELETE,
@@ -45,8 +44,7 @@ ${UNTRUSTED_DATA_SUFFIX}`;
 
 export const PG_WRITE_DESCRIPTION = `Execute a write SQL statement against an Aiven PostgreSQL service.
 
-**Assistant:** If you suggest enabling public DB access, include this line for the user:
-- ⚠️ WARNING: This makes the database reachable from the internet.
+Note: enabling public DB access makes the database reachable from the internet.
 
 Allows DML (INSERT, UPDATE, DELETE) and DDL (CREATE TABLE, ALTER TABLE, CREATE INDEX, etc.).
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -21,6 +21,7 @@ import {
 } from '../types.js';
 import { jsonSchemaToZod } from './json-schema-to-zod.js';
 import { createApiTool } from './api-tool.js';
+import { metricsConfigOverrides } from './metrics-shape.js';
 import { createRequire } from 'node:module';
 import { TOOL_LIST_PICKER_SUFFIX } from '../prompts.js';
 
@@ -183,6 +184,9 @@ export function loadApiTools(client: AivenClient): ToolDefinition[] {
         annotations: deriveAnnotations(entry.method, entry.readOnly, entry.destructive, entry.openWorld),
         defaults: entry.defaults,
         responseFilter: entry.response_filter,
+        // Metrics responses are too large to return whole; the overrides add overview/detail
+        // shaping for that one tool (no-op for all others).
+        ...metricsConfigOverrides(entry.name, inputSchema),
       },
       client
     );

--- a/src/tools/response-filter.ts
+++ b/src/tools/response-filter.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ResponseFilterConfig } from '../types.js';
 
-const SEARCH_PARAMS = new Set(['search', 'limit', 'offset']);
+export const SEARCH_PARAMS = ['search', 'limit', 'offset'] as const;
 export const DEFAULT_LIST_LIMIT = 15;
 const AUTO_RETURN_ALL_THRESHOLD = 30;
 
@@ -39,11 +39,6 @@ export function extendSchemaWithSearch(
   return baseSchema.extend(extra).passthrough();
 }
 
-export function stripSearchParams(args: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(args).filter(([key]) => !SEARCH_PARAMS.has(key))
-  );
-}
 
 function pickFields(
   item: Record<string, unknown>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,13 @@ export interface ApiToolConfig {
   annotations: ToolAnnotations;
   defaults?: Record<string, unknown> | undefined;
   responseFilter?: ResponseFilterConfig | undefined;
+  /** Transform applied to the (redacted, filtered) response before it is returned. Receives
+   *  the input args so it can scope the response to what the caller requested. */
+  postProcess?:
+    | ((data: Record<string, unknown>, args: Record<string, unknown>) => Record<string, unknown>)
+    | undefined;
+  /** Input params consumed client-side (by postProcess) — never forwarded to the Aiven API. */
+  clientOnlyParams?: readonly string[] | undefined;
 }
 
 export interface ServiceConnectionInfo {

--- a/tests/runtime/metrics-shape.test.ts
+++ b/tests/runtime/metrics-shape.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { shapeMetricsResponse } from '../../src/tools/metrics-shape.js';
+
+interface RawGroup {
+  data: {
+    cols: { label: string; type: string }[];
+    rows: unknown[][];
+  };
+}
+
+interface Overview {
+  available_metrics: string[];
+  overview: Record<
+    string,
+    {
+      time_range: [string, string] | null;
+      series: { series: string; points: number; min: number | null; avg: number | null; max: number | null; latest: number | null }[];
+    }
+  >;
+  note: string;
+}
+
+interface Detail {
+  metrics: Record<string, RawGroup>;
+  returned_metrics: string[];
+  unmatched_requested?: string[];
+  note: string;
+}
+
+function makeGroup(cols: string[], dataRows: (string | number)[][]): RawGroup {
+  const colDefs = cols.map((label, i) => ({ label, type: i === 0 ? 'date' : 'number' }));
+  return {
+    data: {
+      cols: colDefs,
+      // The real API echoes the column defs as the first row; shaping must skip it.
+      rows: [colDefs, ...dataRows],
+    },
+  };
+}
+
+function sample(): { metrics: Record<string, RawGroup> } {
+  return {
+    metrics: {
+      cpu_usage: makeGroup(
+        ['time', 'node-a (master)', 'node-b (standby)'],
+        [
+          ['Date(2026,6,22,10,0,0)', 5, 7],
+          ['Date(2026,6,22,10,1,0)', 15, 9],
+          ['Date(2026,6,22,10,2,0)', 10, 11],
+        ]
+      ),
+      mem_usage: makeGroup(
+        ['time', 'node-a (master)'],
+        [
+          ['Date(2026,6,22,10,0,0)', 41.2],
+          ['Date(2026,6,22,10,2,0)', 43.9],
+        ]
+      ),
+    },
+  };
+}
+
+describe('shapeMetricsResponse — overview (no metrics arg)', () => {
+  it('returns available names and per-series stats', () => {
+    const out = shapeMetricsResponse(sample(), {}) as unknown as Overview;
+
+    expect(out.available_metrics).toEqual(['cpu_usage', 'mem_usage']);
+    const cpu = out.overview.cpu_usage;
+    expect(cpu.time_range).toEqual(['Date(2026,6,22,10,0,0)', 'Date(2026,6,22,10,2,0)']);
+    expect(cpu.series[0]).toMatchObject({
+      series: 'node-a (master)',
+      points: 3,
+      min: 5,
+      avg: 10,
+      max: 15,
+      latest: 10,
+    });
+    expect(out.note).toContain('cpu_usage');
+  });
+
+  it('stays small for a large multi-group payload', () => {
+    const groups: Record<string, RawGroup> = {};
+    for (const name of ['cpu_usage', 'mem_usage', 'diskio_read', 'net_send']) {
+      const rows: (string | number)[][] = [];
+      for (let i = 0; i < 120; i++) rows.push([`Date(2026,6,22,10,${String(i)},0)`, i * 0.5, i * 0.25]);
+      groups[name] = makeGroup(['time', 'node-a', 'node-b'], rows);
+    }
+    const raw = { metrics: groups };
+    const out = shapeMetricsResponse(raw, {});
+    expect(JSON.stringify(out).length).toBeLessThan(2_500);
+    expect(JSON.stringify(raw).length).toBeGreaterThan(10_000);
+  });
+
+  it('handles empty series without throwing', () => {
+    const out = shapeMetricsResponse(
+      { metrics: { cpu_usage: makeGroup(['time', 'node-a'], []) } },
+      {}
+    ) as unknown as Overview;
+    expect(out.overview.cpu_usage.time_range).toBeNull();
+    expect(out.overview.cpu_usage.series[0]).toMatchObject({ points: 0, min: null });
+  });
+});
+
+describe('shapeMetricsResponse — detail (metrics arg set)', () => {
+  it('returns the FULL untouched series for requested metrics only', () => {
+    const out = shapeMetricsResponse(sample(), { metrics: ['cpu_usage'] }) as unknown as Detail;
+
+    expect(out.returned_metrics).toEqual(['cpu_usage']);
+    expect(Object.keys(out.metrics)).toEqual(['cpu_usage']);
+    const rows = out.metrics.cpu_usage.data.rows;
+    expect(rows).toHaveLength(4); // header echo + 3 data rows, untouched
+    expect(rows[2]).toEqual(['Date(2026,6,22,10,1,0)', 15, 9]);
+    expect(out.note).toContain('mem_usage'); // other metrics still discoverable
+  });
+
+  it('is case-insensitive and reports unmatched names', () => {
+    const out = shapeMetricsResponse(sample(), {
+      metrics: ['CPU_USAGE', 'bogus'],
+    }) as unknown as Detail;
+    expect(out.returned_metrics).toEqual(['cpu_usage']);
+    expect(out.unmatched_requested).toEqual(['bogus']);
+  });
+
+  it('returns the available list when nothing matches', () => {
+    const out = shapeMetricsResponse(sample(), { metrics: ['bogus'] }) as unknown as {
+      metrics: Record<string, unknown>;
+      available_metrics: string[];
+    };
+    expect(out.metrics).toEqual({});
+    expect(out.available_metrics).toEqual(['cpu_usage', 'mem_usage']);
+  });
+});
+
+describe('shapeMetricsResponse — passthrough', () => {
+  it('leaves non-metrics responses unchanged', () => {
+    expect(shapeMetricsResponse({ foo: 'bar' }, {})).toEqual({ foo: 'bar' });
+    expect(shapeMetricsResponse({ metrics: 'nope' }, {})).toEqual({ metrics: 'nope' });
+    const noTable = { metrics: { weird: { something: 1 } } };
+    expect(shapeMetricsResponse(noTable, {})).toEqual(noTable);
+  });
+});

--- a/tests/runtime/tool-result-limit.test.ts
+++ b/tests/runtime/tool-result-limit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { applyToolResultCharCap } from '../../src/tool-result-limit.js';
+
+const ENV_KEY = 'MCP_MAX_TOOL_RESULT_CHARS';
+const savedEnv = process.env[ENV_KEY];
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env['MCP_MAX_TOOL_RESULT_CHARS'];
+  else process.env[ENV_KEY] = savedEnv;
+});
+
+describe('applyToolResultCharCap', () => {
+  it('returns text unchanged when under the cap', () => {
+    process.env[ENV_KEY] = '1000';
+    const text = 'short response';
+    expect(applyToolResultCharCap(text, 'tool')).toBe(text);
+  });
+
+  it('returns text unchanged when the cap is disabled (0)', () => {
+    process.env[ENV_KEY] = '0';
+    const text = 'x'.repeat(500_000);
+    expect(applyToolResultCharCap(text, 'tool')).toBe(text);
+  });
+
+  it('truncates a large JSON payload into a still-parseable prefix', () => {
+    process.env[ENV_KEY] = '3000';
+    // Pretty-printed JSON like wrapUntrustedResponse produces (JSON.stringify(data, null, 2)).
+    const rows: unknown[][] = [];
+    for (let i = 0; i < 400; i++) {
+      rows.push([`Date(2026,6,22,10,${String(i)},30)`, 5.7567 + i * 0.001, 5.6922 + i * 0.001]);
+    }
+    const text = JSON.stringify({ metrics: { cpu_usage: { data: { rows } } } }, null, 2);
+    expect(text.length).toBeGreaterThan(3000);
+
+    const out = applyToolResultCharCap(text, 'aiven_service_metrics_fetch');
+    expect(out.length).toBeLessThanOrEqual(3000);
+
+    // Body is everything before the trim notice; it must be valid JSON despite truncation.
+    const body = out.split('\n\n---\n')[0] ?? out;
+    const parsed = JSON.parse(body) as { metrics: { cpu_usage: { data: { rows: unknown[] } } } };
+    // Some rows were dropped, but the structure is intact and parseable.
+    const kept = parsed.metrics.cpu_usage.data.rows;
+    expect(kept.length).toBeGreaterThan(0);
+    expect(kept.length).toBeLessThan(400);
+  });
+
+  it('closes an open string when the cut lands inside a quoted value', () => {
+    process.env[ENV_KEY] = '80';
+    const text = JSON.stringify({ items: ['aaaaaaaaaa', 'bbbbbbbbbb', 'cccccccccc'] }, null, 2);
+    const out = applyToolResultCharCap(text, 'tool');
+    const body = out.split('\n\n---\n')[0] ?? out;
+    expect(() => JSON.parse(body) as unknown).not.toThrow();
+  });
+
+  it('falls back to a hard slice when there is no newline to back off to', () => {
+    process.env[ENV_KEY] = '500';
+    const text = 'x'.repeat(5000); // single line, no newline
+    const out = applyToolResultCharCap(text, 'tool');
+    expect(out.length).toBeLessThanOrEqual(500);
+    expect(out).toContain('**Trimmed:**');
+  });
+});


### PR DESCRIPTION
Anthropic MCP directory review requires tool descriptions to state only what the tool does, its inputs, and what it returns.

## Changes

**Descriptions** — removed the local-file-write directive from `aiven_project_get_service_logs`, the `**Assistant:**` blocks in pg/kafka descriptions, the AskUserQuestion/Claude Code hint in `TOOL_LIST_PICKER_SUFFIX`, "never guess project names", and the ASCII-dashboard rendering mandate. Security warnings kept as neutral facts.

**Metrics tool** — its description previously told the assistant to summarize the ~100KB response; without that instruction the raw payload overflows the 100KB result cap and truncates into invalid JSON. `aiven_service_metrics_fetch` now returns a per-series min/avg/max/latest overview (~6KB) by default, or the full untouched time series for groups named via a new `metrics` param (~16KB per group). Both modes verified against a live service.

**Truncation** — when a response still exceeds the cap, the cut now lands on a line boundary and open brackets are closed, so the retained JSON prefix parses instead of failing mid-token.

Not addressed here: the reviewer's minor note about documenting aiven.live domain ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)